### PR TITLE
Fix overlaping product titles on mobile

### DIFF
--- a/components/product/ProductCard/ProductCard.module.css
+++ b/components/product/ProductCard/ProductCard.module.css
@@ -101,7 +101,7 @@
 }
 
 .productTitle {
-  @apply pt-2 max-w-full w-full;
+  @apply max-w-full w-full;
   font-size: 2rem;
   letter-spacing: 0.4px;
 

--- a/components/product/ProductCard/ProductCard.module.css
+++ b/components/product/ProductCard/ProductCard.module.css
@@ -101,7 +101,7 @@
 }
 
 .productTitle {
-  @apply max-w-full w-full;
+  @apply pt-0 max-w-full w-full leading-extra-loose;
   font-size: 2rem;
   letter-spacing: 0.4px;
 

--- a/components/product/ProductCard/ProductCard.module.css
+++ b/components/product/ProductCard/ProductCard.module.css
@@ -88,10 +88,11 @@
   }
 
   & .productTitle {
-    margin-top: -7px;
+    @apply pt-2;
     font-size: 1rem;
+
     & span {
-      line-height: 3;
+      @apply leading-extra-loose;
     }
   }
 

--- a/components/product/ProductCard/ProductCard.tsx
+++ b/components/product/ProductCard/ProductCard.tsx
@@ -57,7 +57,7 @@ const ProductCard: FC<Props> = ({
             <div className={s.squareBg} />
             <div className="flex flex-row justify-between box-border w-full z-20 absolute">
               <div className="absolute top-0 left-0 pr-16 max-w-full">
-                <h3 className={s.productTitle}>
+                <h3 className={cn('leading-extra-loose pt-0 sm:pt-2 sm:leading-normal', s['productTitle'])}>
                   <span>{p.name}</span>
                 </h3>
                 <span className={s.productPrice}>{price}</span>

--- a/components/product/ProductCard/ProductCard.tsx
+++ b/components/product/ProductCard/ProductCard.tsx
@@ -57,7 +57,7 @@ const ProductCard: FC<Props> = ({
             <div className={s.squareBg} />
             <div className="flex flex-row justify-between box-border w-full z-20 absolute">
               <div className="absolute top-0 left-0 pr-16 max-w-full">
-                <h3 className={cn('leading-extra-loose pt-0 sm:pt-2 sm:leading-normal', s['productTitle'])}>
+                <h3 className={s.productTitle}>
                   <span>{p.name}</span>
                 </h3>
                 <span className={s.productPrice}>{price}</span>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,6 +46,9 @@ module.exports = {
         magical:
           'rgba(0, 0, 0, 0.02) 0px 30px 30px, rgba(0, 0, 0, 0.03) 0px 0px 8px, rgba(0, 0, 0, 0.05) 0px 1px 0px',
       },
+      lineHeight: {
+        'extra-loose': '2.3'
+      }
     },
   },
   plugins: [require('@tailwindcss/ui')],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -47,7 +47,7 @@ module.exports = {
           'rgba(0, 0, 0, 0.02) 0px 30px 30px, rgba(0, 0, 0, 0.03) 0px 0px 8px, rgba(0, 0, 0, 0.05) 0px 1px 0px',
       },
       lineHeight: {
-        'extra-loose': '2.3'
+        'extra-loose': '2.2'
       }
     },
   },


### PR DESCRIPTION
Hey guys, first of all, that's an amazing project and I'm pretty sure it will help lot of people that want to start a fast ecommerce and have great performance at the same time!

I found a minor "bug" on mobile that you might want to fix. On mobile devices if the title is too big, it overlaps. 
Follow the images bellow:

before | after
--------|------
![broken-overlap](https://user-images.githubusercontent.com/3991845/97361377-317aa800-187e-11eb-977b-edcc4fcf7dad.png) | ![fixed-overlap](https://user-images.githubusercontent.com/3991845/97361387-36d7f280-187e-11eb-8862-6be8bcaca24a.png)

In order to fix that, I tried to follow Tailwind conventions, like having an [extra-loose](https://tailwindcss.com/docs/line-height#customizing) `line-height` variable.

This one solves #9