### PR TITLE
Remove unnecessary bg-opacity extension

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,9 +10,6 @@ module.exports = {
       maxWidth: {
         '8xl': '1920px',
       },
-      backgroundOpacity: {
-        075: '0.75',
-      },
       colors: {
         primary: 'var(--primary)',
         'primary-2': 'var(--primary-2)',


### PR DESCRIPTION
Tailwind already includes a .75 bgOpacity utility.

https://tailwindcss.com/docs/background-opacity#app