### PR TITLE
Fix some minor problems with style between mobile and desktop

### DIFF
--- a/components/core/Searchbar/Searchbar.module.css
+++ b/components/core/Searchbar/Searchbar.module.css
@@ -1,6 +1,9 @@
 .input {
   @apply bg-transparent px-3 py-2 appearance-none w-full transition duration-150 ease-in-out pr-10;
-  min-width: 300px;
+
+  @screen sm {
+    min-width: 300px;
+  }
 }
 
 .input:focus {

--- a/components/product/ProductView/ProductView.module.css
+++ b/components/product/ProductView/ProductView.module.css
@@ -78,8 +78,13 @@
 }
 
 .button {
-  min-width: 300px;
   text-align: center;
+  width: 100%;
+  max-width: 300px;
+
+  @screen sm {
+    min-width: 300px;
+  }
 }
 
 .wishlistButton {


### PR DESCRIPTION
Hey folks,
First of all, thanks for all your effort for creating this amazing project!

I found some minor "bugs" on mobile/desktop that you might want to fix.

> Follow the images bellow:

| Current behaviour | Expected/Proposed behaviour |
|----------|----------------------------------------|
| <img width="398" alt="Screenshot 2020-10-28 at 10 36 51" src="https://user-images.githubusercontent.com/5417662/97426682-b95ac380-190b-11eb-82da-2a55614df69b.png"> | <img width="398" alt="Screenshot 2020-10-28 at 10 39 17" src="https://user-images.githubusercontent.com/5417662/97426685-bbbd1d80-190b-11eb-9229-4a735f5cd95b.png"> |
|----|----|
| <img width="1211" alt="Screenshot 2020-10-28 at 10 40 15" src="https://user-images.githubusercontent.com/5417662/97426775-d8f1ec00-190b-11eb-8b03-0c9346442f01.png"> | <img width="1153" alt="Screenshot 2020-10-28 at 10 40 39" src="https://user-images.githubusercontent.com/5417662/97426766-d4c5ce80-190b-11eb-8b33-c706706df026.png"> |

> **Note:** Please ignore the colours (`tomato` and `#4CAF50`) last two images, they were just illustrative about what is "incorrect / correct".



 








