### PR TITLE
Cart Count will be Number of items rather than sum total quantity

### DIFF
--- a/components/core/UserNav/UserNav.tsx
+++ b/components/core/UserNav/UserNav.tsx
@@ -14,7 +14,7 @@ interface Props {
   className?: string
 }
 
-const countItem = (count: number, item: any) => count + item.quantity
+const countItem = (count: number, item: any) => count + (item.quantity > 0 ? 1 : 0)
 const countItems = (count: number, items: any[]) =>
   items.reduce(countItem, count)
 


### PR DESCRIPTION
Fixes #21  earlier cart used to have sum of the total items rather than no. of items