### PR TITLE
Remove unused hooks/* files

### DIFF
--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,1 +1,0 @@
-export { default as useCart } from './useCart'


### PR DESCRIPTION
The build is failing on master with:
```
10:39:53 | Failed to compile.
-- | --
10:39:53 | ./hooks/index.ts:1:36
10:39:53 | Type error: File '/vercel/workpath0/hooks/useCart.ts' is not a module.
```

This PR removes the files in the `hooks` directory since they are not used anywhere.