### PR TITLE
Change All link href in Navbar

### DIFF
--- a/components/common/Navbar/Navbar.tsx
+++ b/components/common/Navbar/Navbar.tsx
@@ -34,7 +34,7 @@ const Navbar: FC = () => {
               </a>
             </Link>
             <nav className="space-x-4 ml-6 hidden lg:block">
-              <Link href="/">
+              <Link href="/search">
                 <a className={s.link}>All</a>
               </Link>
               <Link href="/search?q=clothes">


### PR DESCRIPTION
Changed Navbar "All" link to point to search (but with no specific query) instead of reloading the page (the ACME logo next to it already does that)

The last PR (vercel/commerce#61) went stale so I updated it