### PR TITLE
fix locale category rewrite

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -53,6 +53,7 @@ module.exports = bundleAnalyzer({
         // This rewrite will also handle `/search/designers`
         source: '/search/:category',
         destination: '/search',
+        locale: false
       },
     ]
   },


### PR DESCRIPTION
The next.js is having an error while trying to automatically rewrites each source and destination prefixed to handle the configured locales because of the search category route. I added a locale false to this route to fix this problem

This is the error that was fixed when we tried to change the category: 

![locale bug](https://user-images.githubusercontent.com/45166647/102722254-b0b8b500-42de-11eb-8067-4cb4c49387fe.png)
