### PR TITLE
Fix text component

### DIFF
--- a/components/ui/Text/Text.tsx
+++ b/components/ui/Text/Text.tsx
@@ -26,7 +26,7 @@ const Text: FunctionComponent<Props> = ({
   const componentsMap: {
     [P in Variant]: React.ComponentType<any> | string
   } = {
-    body: 'p',
+    body: 'div',
     heading: 'h1',
     pageHeading: 'h1',
     sectionHeading: 'h2',


### PR DESCRIPTION
The text component was creating an <p> element and receiving an HTML inside it. But when you have a <p> tag inside another <p> tag you can have some problems.

In this case, the product description for example was not being displayed after you reload the page