### PR TITLE
Fix Product Image slider

### DIFF
--- a/components/product/ProductView/ProductView.tsx
+++ b/components/product/ProductView/ProductView.tsx
@@ -86,7 +86,7 @@ const ProductView: FC<Props> = ({ product }) => {
           </div>
 
           <div className={s.sliderContainer}>
-            <ProductSlider>
+            <ProductSlider key={product.entityId}>
               {product.images.edges?.map((image, i) => (
                 <div key={image?.node.urlOriginal} className={s.imageContainer}>
                   <Image


### PR DESCRIPTION
Fixed issue #136 by adding the product entityID as an unique key prop to the `ProductSlider` component.