### PR TITLE
Fix Typo

### DIFF
--- a/lib/defaults.ts
+++ b/lib/defaults.ts
@@ -1,6 +1,6 @@
 // Fallback to CMS Data
 
-export const defatultPageProps = {
+export const defaultPageProps = {
   header: {
     links: [
       {

--- a/pages/[...pages].tsx
+++ b/pages/[...pages].tsx
@@ -7,10 +7,12 @@ import getSlug from '@lib/get-slug'
 import { missingLocaleInPages } from '@lib/usage-warns'
 import { Layout } from '@components/common'
 import { Text } from '@components/ui'
+
 import { getConfig } from '@framework/api'
 import getPage from '@framework/api/operations/get-page'
 import getAllPages from '@framework/api/operations/get-all-pages'
 import { defatultPageProps } from '@lib/defaults'
+
 
 export async function getStaticProps({
   preview,
@@ -34,7 +36,7 @@ export async function getStaticProps({
   }
 
   return {
-    props: { ...defatultPageProps, pages, page },
+    props: { ...defaultPageProps, pages, page },
     revalidate: 60 * 60, // Every hour
   }
 }

--- a/pages/[...pages].tsx
+++ b/pages/[...pages].tsx
@@ -3,16 +3,14 @@ import type {
   GetStaticPropsContext,
   InferGetStaticPropsType,
 } from 'next'
+import { Text } from '@components/ui'
+import { Layout } from '@components/common'
 import getSlug from '@lib/get-slug'
 import { missingLocaleInPages } from '@lib/usage-warns'
-import { Layout } from '@components/common'
-import { Text } from '@components/ui'
-
 import { getConfig } from '@framework/api'
 import getPage from '@framework/api/operations/get-page'
 import getAllPages from '@framework/api/operations/get-all-pages'
-import { defatultPageProps } from '@lib/defaults'
-
+import { defaultPageProps } from '@lib/defaults'
 
 export async function getStaticProps({
   preview,

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,10 +1,4 @@
-import Document, {
-  DocumentContext,
-  Head,
-  Html,
-  Main,
-  NextScript,
-} from 'next/document'
+import Document, { Head, Html, Main, NextScript } from 'next/document'
 
 class MyDocument extends Document {
   render() {

--- a/pages/wishlist.tsx
+++ b/pages/wishlist.tsx
@@ -6,7 +6,7 @@ import { Layout } from '@components/common'
 import { Heart } from '@components/icons'
 import { Text, Container } from '@components/ui'
 import { WishlistCard } from '@components/wishlist'
-import { defatultPageProps } from '@lib/defaults'
+import { defaultPageProps } from '@lib/defaults'
 
 export async function getStaticProps({
   preview,
@@ -15,7 +15,7 @@ export async function getStaticProps({
   const config = getConfig({ locale })
   const { pages } = await getAllPages({ config, preview })
   return {
-    props: { ...defatultPageProps, pages },
+    props: { ...defaultPageProps, pages },
   }
 }
 


### PR DESCRIPTION
The defaultPageProps object had a typo in the name
Co-authored-by: B <curciobelen@gmail.com>