### PR TITLE
chore: Remove import never used

### DIFF
--- a/components/common/Avatar/Avatar.tsx
+++ b/components/common/Avatar/Avatar.tsx
@@ -1,4 +1,3 @@
-import cn from 'classnames'
 import { FC, useState, useMemo, useRef, useEffect } from 'react'
 import { getRandomPairOfColors } from '@lib/colors'
 


### PR DESCRIPTION
This PR removes from `Avatar.tsx` an import never used in the file. 

Feel free to review it.

Issue: #188 