### PR TITLE
Update sort filter texts on mobile

### DIFF
--- a/components/search.tsx
+++ b/components/search.tsx
@@ -14,12 +14,12 @@ import useSearch from '@framework/product/use-search'
 import getSlug from '@lib/get-slug'
 import rangeMap from '@lib/range-map'
 
-const SORT = Object.entries({
+const SORT = {
   'trending-desc': 'Trending',
   'latest-desc': 'Latest arrivals',
   'price-asc': 'Price: Low to high',
   'price-desc': 'Price: High to low',
-})
+}
 
 import {
   filterQuery,
@@ -351,7 +351,7 @@ export default function Search({ categories, brands }: SearchPropsType) {
                   aria-haspopup="true"
                   aria-expanded="true"
                 >
-                  {sort ? `Sort: ${sort}` : 'Relevance'}
+                  {sort ? SORT[sort as keyof typeof SORT] : 'Relevance'}
                   <svg
                     className="-mr-1 ml-2 h-5 w-5"
                     xmlns="http://www.w3.org/2000/svg"
@@ -398,7 +398,7 @@ export default function Search({ categories, brands }: SearchPropsType) {
                         </a>
                       </Link>
                     </li>
-                    {SORT.map(([key, text]) => (
+                    {Object.entries(SORT).map(([key, text]) => (
                       <li
                         key={key}
                         className={cn(


### PR DESCRIPTION
### Description
At **search** page, on mobile devices, the **sort** button shows the content of the query (_e.g._, **Sort: latest-desc**). I though that by changing SORT to a plain object it would be easier to access the value of the key (the label), without requiring iterating or filtering the entries. Not sure if is the best approach, hope it can be of some help :)


### Screenshots

|Before                    |After
| ---------------------------------- | ---------------------------------- |
| ![before](https://user-images.githubusercontent.com/50624358/107094574-02ad8f80-67e6-11eb-83da-ad2657383c50.png)| ![after](https://user-images.githubusercontent.com/50624358/107094582-093c0700-67e6-11eb-9aa0-aee9003ce443.png) |