### PR TITLE
fix: unused prop

### DIFF
--- a/components/ui/Modal/Modal.tsx
+++ b/components/ui/Modal/Modal.tsx
@@ -8,8 +8,8 @@ import {
   clearAllBodyScrollLocks,
 } from 'body-scroll-lock'
 import FocusTrap from '@lib/focus-trap'
+
 interface Props {
-  className?: string
   children?: any
   open?: boolean
   onClose: () => void


### PR DESCRIPTION
the `className` prop is unused on the Modal Component, so does not make sense the prop interface has that.