### PR TITLE
Bigcommerce options fix

### DIFF
--- a/components/cart/CartItem/CartItem.tsx
+++ b/components/cart/CartItem/CartItem.tsx
@@ -116,15 +116,34 @@ const CartItem = ({
         </Link>
         {options && options.length > 0 ? (
           <div className="">
-            {options.map((option: ItemOption, i: number) => (
-              <span
-                key={`${item.id}-${option.name}`}
-                className="text-sm font-semibold text-accents-7"
-              >
-                {option.value}
-                {i === options.length - 1 ? '' : ', '}
-              </span>
-            ))}
+            {/** attempt to sort the options array alphabetically by option name, that way options will always appear in the same order */}
+            {options
+              .sort((first: any, second: any) => {
+                if (first.name && second.name) {
+                  return first.name < second.name
+                    ? -1
+                    : first.name > second.name
+                    ? 1
+                    : 0
+                } else {
+                  if (JSON.stringify(first) < JSON.stringify(second)) {
+                    return -1
+                  } else if (JSON.stringify(first) > JSON.stringify(second)) {
+                    return 1
+                  } else {
+                    return 0
+                  }
+                }
+              })
+              .map((option: ItemOption, i: number) => (
+                <span
+                  key={`${item.id}-${option.name}`}
+                  className="text-sm font-semibold text-accents-7"
+                >
+                  {option.value}
+                  {i === options.length - 1 ? '' : ', '}
+                </span>
+              ))}
           </div>
         ) : null}
         <div className="flex items-center mt-3">

--- a/framework/bigcommerce/lib/normalize.ts
+++ b/framework/bigcommerce/lib/normalize.ts
@@ -106,6 +106,7 @@ function normalizeLineItem(item: any): LineItem {
       listPrice: item.list_price,
     },
     path: item.url.split('/')[3],
+    options: item.options,
     discounts: item.discounts.map((discount: any) => ({
       value: discount.discounted_amount,
     })),

--- a/framework/commerce/types.ts
+++ b/framework/commerce/types.ts
@@ -17,6 +17,7 @@ export type LineItem = {
   // A human-friendly unique string automatically generated from the product’s name
   path: string
   variant: ProductVariant
+  options?: any[]
 }
 
 export type Measurement = {

--- a/framework/shopify/types.ts
+++ b/framework/shopify/types.ts
@@ -10,9 +10,7 @@ export type ShopifyCheckout = {
 export type Cart = Core.Cart & {
   lineItems: LineItem[]
 }
-export interface LineItem extends Core.LineItem {
-  options?: any[]
-}
+export type LineItem = Core.LineItem
 
 /**
  * Cart mutations


### PR DESCRIPTION
CartItem.tsx attempts to access the `options` field of `LineItem`, however this field is only available with the Shopify provider.
This fix:
- adds the `options` field to the core `LineItem` type, so it can be accessed regardless of provider.
- removes the `LineItem` extension from the Shopify types file, since it is no longer needed
- updates the `normalizeLineItem` function for BigCommerce to copy `item.options` to the `options` field of the returned `LineItem`
- Sorts the `options` array before displaying them in CartItem.tsx, so that options will always appear to the user in the same order (i.e. [size], [color])