### PR TITLE
Fetch only first 100 best selling products

### DIFF
--- a/framework/shopify/customer/use-customer.tsx
+++ b/framework/shopify/customer/use-customer.tsx
@@ -10,11 +10,15 @@ export const handler: SWRHook<Customer | null> = {
     query: getCustomerQuery,
   },
   async fetcher({ options, fetch }) {
-    const data = await fetch<any | null>({
-      ...options,
-      variables: { customerAccessToken: getCustomerToken() },
-    })
-    return data.customer ?? null
+    const customerAccessToken = getCustomerToken()
+    if (customerAccessToken) {
+      const data = await fetch({
+        ...options,
+        variables: { customerAccessToken: getCustomerToken() },
+      })
+      return data.customer
+    }
+    return null
   },
   useHook: ({ useData }) => (input) => {
     return useData({

--- a/framework/shopify/product/get-all-product-paths.ts
+++ b/framework/shopify/product/get-all-product-paths.ts
@@ -1,6 +1,4 @@
-import { Product } from '@commerce/types'
 import { getConfig, ShopifyConfig } from '../api'
-import fetchAllProducts from '../api/utils/fetch-all-products'
 import { ProductEdge } from '../schema'
 import getAllProductsPathsQuery from '../utils/queries/get-all-products-paths-query'
 
@@ -21,21 +19,22 @@ const getAllProductPaths = async (options?: {
   config?: ShopifyConfig
   preview?: boolean
 }): Promise<ReturnType> => {
-  let { config, variables = { first: 250 } } = options ?? {}
+  let { config, variables = { first: 250, sortKey: 'BEST_SELLING' } } =
+    options ?? {}
   config = getConfig(config)
 
-  const products = await fetchAllProducts({
-    config,
-    query: getAllProductsPathsQuery,
+  const { data } = await config.fetch(getAllProductsPathsQuery, {
     variables,
   })
 
   return {
-    products: products?.map(({ node: { handle } }: ProductEdge) => ({
-      node: {
-        path: `/${handle}`,
-      },
-    })),
+    products: data.products?.edges?.map(
+      ({ node: { handle } }: ProductEdge) => ({
+        node: {
+          path: `/${handle}`,
+        },
+      })
+    ),
   }
 }
 

--- a/framework/shopify/product/get-all-product-paths.ts
+++ b/framework/shopify/product/get-all-product-paths.ts
@@ -19,7 +19,7 @@ const getAllProductPaths = async (options?: {
   config?: ShopifyConfig
   preview?: boolean
 }): Promise<ReturnType> => {
-  let { config, variables = { first: 250, sortKey: 'BEST_SELLING' } } =
+  let { config, variables = { first: 100, sortKey: 'BEST_SELLING' } } =
     options ?? {}
   config = getConfig(config)
 

--- a/framework/shopify/product/get-all-products.ts
+++ b/framework/shopify/product/get-all-products.ts
@@ -27,10 +27,9 @@ const getAllProducts = async (options: {
     { variables }
   )
 
-  const products =
-    data.products?.edges?.map(({ node: p }: ProductEdge) =>
-      normalizeProduct(p)
-    ) ?? []
+  const products = data.products?.edges?.map(({ node: p }: ProductEdge) =>
+    normalizeProduct(p)
+  )
 
   return {
     products,


### PR DESCRIPTION
Change get-all-product-paths.ts to fetch only first 100  best selling products when generating paths (it was fetching all products using nextPage cursor before)