### PR TITLE
optionsSelections takes an array of options objs

### DIFF
--- a/framework/bigcommerce/api/utils/parse-item.ts
+++ b/framework/bigcommerce/api/utils/parse-item.ts
@@ -10,7 +10,7 @@ type BCCartItemBody = {
   product_id: number
   variant_id: number
   quantity?: number
-  option_selections?: OptionSelections
+  option_selections?: OptionSelections[]
 }
 
 export const parseWishlistItem = (

--- a/framework/bigcommerce/types/cart.ts
+++ b/framework/bigcommerce/types/cart.ts
@@ -40,7 +40,7 @@ export type OptionSelections = {
 
 export type CartItemBody = Core.CartItemBody & {
   productId: string // The product id is always required for BC
-  optionSelections?: OptionSelections
+  optionSelections?: OptionSelections[]
 }
 
 export type CartTypes = {


### PR DESCRIPTION
When adding an item to cart with product options, the `optionSelections` member should accept an array of product option objects. Currently this causes an error if you try to add products with options that match commerce's `CartItemBody` type
<https://developer.bigcommerce.com/api-reference/storefront/carts/cart-items/addcartlineitem> 