### PR TITLE
Fix unexpected uppercase

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -77,7 +77,6 @@ html {
   height: 100%;
   box-sizing: border-box;
   touch-action: manipulation;
-  font-feature-settings: 'case' 1, 'rlig' 1, 'calt' 0;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
# Everything is in uppercase

![Captura de tela de 2021-07-11 18-36-54](https://user-images.githubusercontent.com/51221635/125210909-fa67ed80-e278-11eb-9ac7-a8c876532110.png)

This problem happened to me in the versions:

OS:  Linux Mint 20 Xfce 64 bits
Browser: Google Chrome is version 87.0.4280.141 64 bits

_and_

OS:  Ubuntu 20.04 64bits
Browser: Chrome version 91.0.4472.114 64 bits

I remove this property  `font-feature-settings` and the problem was fixed

![Captura de tela de 2021-07-11 18-55-52](https://user-images.githubusercontent.com/51221635/125211015-a90c2e00-e279-11eb-9a85-1659e2fe6492.png)


 ---
Thank you