### PR TITLE
BigCommerce Category Fix

### DIFF
--- a/framework/bigcommerce/product/use-search.tsx
+++ b/framework/bigcommerce/product/use-search.tsx
@@ -22,7 +22,7 @@ export const handler: SWRHook<SearchProductsHook> = {
     const url = new URL(options.url!, 'http://a')
 
     if (search) url.searchParams.set('search', search)
-    if (Number.isInteger(categoryId))
+    if (Number.isInteger(Number(categoryId)))
       url.searchParams.set('categoryId', String(categoryId))
     if (Number.isInteger(brandId))
       url.searchParams.set('brandId', String(brandId))


### PR DESCRIPTION
Fix for [issue #410 ](https://github.com/vercel/commerce/issues/410).

BigCommerce category IDs are passed into useSearch as a string from `components/search.tsx`. Because useSearch checks for `Number.isInteger(categoryId)`, the category ID is not actually passed into the backend to filter products on the page. Instead, each category page just shows all products by default.

Please let me know if you have any questions or would like to see this fixed in a different way!