### PR TITLE
Update ProductView.tsx

### DIFF
--- a/components/product/ProductView/ProductView.tsx
+++ b/components/product/ProductView/ProductView.tsx
@@ -58,7 +58,7 @@ const ProductView: FC<ProductViewProps> = ({ product, relatedProducts }) => {
             )}
           </div>
 
-          <ProductSidebar product={product} className={s.sidebar} />
+          <ProductSidebar key={product.id} product={product} className={s.sidebar} />
         </div>
         <hr className="mt-7 border-accent-2" />
         <section className="py-12 px-6 mb-10">


### PR DESCRIPTION
When you navigate to other product page, the options selected by default don't change and the options from the last product navigated are used. Adding a key to "ProductSideBar" component, makes it refresh default options and refresh actual product selected options when i navigate for many products.