### PR TITLE
Remove unused provider config

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,4 @@
-# Available providers: bigcommerce, shopify, swell
+# Available providers: local, bigcommerce, shopify, swell
 COMMERCE_PROVIDER=
 
 BIGCOMMERCE_STOREFRONT_API_URL=

--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,4 @@
-# Available providers: local, bigcommerce, shopify, swell
+# Available providers: local, bigcommerce, shopify, swell, saleor
 COMMERCE_PROVIDER=
 
 BIGCOMMERCE_STOREFRONT_API_URL=

--- a/framework/bigcommerce/index.tsx
+++ b/framework/bigcommerce/index.tsx
@@ -1,7 +1,6 @@
-import type { ReactNode } from 'react'
 import {
-  CommerceConfig,
   CommerceProvider as CoreCommerceProvider,
+  CommerceProviderProps,
   useCommerce as useCoreCommerce,
 } from '@commerce'
 import { bigcommerceProvider } from './provider'
@@ -10,24 +9,12 @@ import type { BigcommerceProvider } from './provider'
 export { bigcommerceProvider }
 export type { BigcommerceProvider }
 
-export const bigcommerceConfig: CommerceConfig = {
-  locale: 'en-us',
-  cartCookie: 'bc_cartId',
-}
-
-export type BigcommerceConfig = Partial<CommerceConfig>
-
-export type BigcommerceProps = {
-  children?: ReactNode
-  locale: string
-} & BigcommerceConfig
-
-export function CommerceProvider({ children, ...config }: BigcommerceProps) {
+export function CommerceProvider({
+  children,
+  ...props
+}: CommerceProviderProps) {
   return (
-    <CoreCommerceProvider
-      provider={bigcommerceProvider}
-      config={{ ...bigcommerceConfig, ...config }}
-    >
+    <CoreCommerceProvider provider={{ ...bigcommerceProvider, ...props }}>
       {children}
     </CoreCommerceProvider>
   )

--- a/framework/bigcommerce/index.tsx
+++ b/framework/bigcommerce/index.tsx
@@ -1,6 +1,5 @@
 import { getCommerceProvider, useCommerce as useCoreCommerce } from '@commerce'
-import { bigcommerceProvider } from './provider'
-import type { BigcommerceProvider } from './provider'
+import { bigcommerceProvider, BigcommerceProvider } from './provider'
 
 export { bigcommerceProvider }
 export type { BigcommerceProvider }

--- a/framework/bigcommerce/index.tsx
+++ b/framework/bigcommerce/index.tsx
@@ -1,23 +1,10 @@
-import {
-  CommerceProvider as CoreCommerceProvider,
-  CommerceProviderProps,
-  useCommerce as useCoreCommerce,
-} from '@commerce'
+import { getCommerceProvider, useCommerce as useCoreCommerce } from '@commerce'
 import { bigcommerceProvider } from './provider'
 import type { BigcommerceProvider } from './provider'
 
 export { bigcommerceProvider }
 export type { BigcommerceProvider }
 
-export function CommerceProvider({
-  children,
-  ...props
-}: CommerceProviderProps) {
-  return (
-    <CoreCommerceProvider provider={{ ...bigcommerceProvider, ...props }}>
-      {children}
-    </CoreCommerceProvider>
-  )
-}
+export const CommerceProvider = getCommerceProvider(bigcommerceProvider)
 
 export const useCommerce = () => useCoreCommerce<BigcommerceProvider>()

--- a/framework/commerce/config.js
+++ b/framework/commerce/config.js
@@ -8,12 +8,12 @@ const merge = require('deepmerge')
 const prettier = require('prettier')
 
 const PROVIDERS = [
+  'local',
   'bigcommerce',
   'saleor',
   'shopify',
   'swell',
   'vendure',
-  'local',
 ]
 
 function getProviderName() {

--- a/framework/commerce/index.tsx
+++ b/framework/commerce/index.tsx
@@ -70,7 +70,7 @@ export type CommerceProviderProps = {
   children?: ReactNode
 } & Partial<CommerceConfig>
 
-export function CommerceProvider<P extends Provider>({
+export function CoreCommerceProvider<P extends Provider>({
   provider,
   children,
 }: CommerceProps<P>) {
@@ -86,6 +86,19 @@ export function CommerceProvider<P extends Provider>({
   )
 
   return <Commerce.Provider value={cfg}>{children}</Commerce.Provider>
+}
+
+export function getCommerceProvider<P extends Provider>(provider: P) {
+  return function CommerceProvider({
+    children,
+    ...props
+  }: CommerceProviderProps) {
+    return (
+      <CoreCommerceProvider provider={{ ...provider, ...props }}>
+        {children}
+      </CoreCommerceProvider>
+    )
+  }
 }
 
 export function useCommerce<P extends Provider>() {

--- a/framework/commerce/index.tsx
+++ b/framework/commerce/index.tsx
@@ -47,46 +47,42 @@ export type Provider = CommerceConfig & {
   }
 }
 
-export type CommerceProps<P extends Provider> = {
-  children?: ReactNode
-  provider: P
-  config: CommerceConfig
-}
-
-export type CommerceConfig = Omit<
-  CommerceContextValue<any>,
-  'providerRef' | 'fetcherRef'
->
-
-export type CommerceContextValue<P extends Provider> = {
-  providerRef: MutableRefObject<P>
-  fetcherRef: MutableRefObject<Fetcher>
+export type CommerceConfig = {
   locale: string
   cartCookie: string
 }
 
+export type CommerceContextValue<P extends Provider> = {
+  providerRef: MutableRefObject<P>
+  fetcherRef: MutableRefObject<Fetcher>
+} & CommerceConfig
+
+export type CommerceProps<P extends Provider> = {
+  children?: ReactNode
+  provider: P
+}
+
+/**
+ * These are the properties every provider should allow when implementing
+ * the core commerce provider
+ */
+export type CommerceProviderProps = {
+  children?: ReactNode
+} & Partial<CommerceConfig>
+
 export function CommerceProvider<P extends Provider>({
   provider,
   children,
-  config,
 }: CommerceProps<P>) {
-  if (!config) {
-    throw new Error('CommerceProvider requires a valid config object')
-  }
-
   const providerRef = useRef(provider)
   // TODO: Remove the fetcherRef
   const fetcherRef = useRef(provider.fetcher)
-  // Because the config is an object, if the parent re-renders this provider
-  // will re-render every consumer unless we memoize the config
+  // If the parent re-renders this provider will re-render every
+  // consumer unless we memoize the config
+  const { locale, cartCookie } = providerRef.current
   const cfg = useMemo(
-    () => ({
-      providerRef,
-      fetcherRef,
-      locale: config.locale,
-      cartCookie: config.cartCookie,
-    }),
-    [config.locale, config.cartCookie]
+    () => ({ providerRef, fetcherRef, locale, cartCookie }),
+    [locale, cartCookie]
   )
 
   return <Commerce.Provider value={cfg}>{children}</Commerce.Provider>

--- a/framework/local/index.tsx
+++ b/framework/local/index.tsx
@@ -1,32 +1,9 @@
-import * as React from 'react'
-import { ReactNode } from 'react'
-import { localProvider } from './provider'
-import {
-  CommerceConfig,
-  CommerceProvider as CoreCommerceProvider,
-  useCommerce as useCoreCommerce,
-} from '@commerce'
+import { getCommerceProvider, useCommerce as useCoreCommerce } from '@commerce'
+import { localProvider, LocalProvider } from './provider'
 
-export const localConfig: CommerceConfig = {
-  locale: 'en-us',
-  cartCookie: 'session',
-}
+export { localProvider }
+export type { LocalProvider }
 
-export function CommerceProvider({
-  children,
-  ...config
-}: {
-  children?: ReactNode
-  locale: string
-} & Partial<CommerceConfig>) {
-  return (
-    <CoreCommerceProvider
-      provider={localProvider}
-      config={{ ...localConfig, ...config }}
-    >
-      {children}
-    </CoreCommerceProvider>
-  )
-}
+export const CommerceProvider = getCommerceProvider(localProvider)
 
-export const useCommerce = () => useCoreCommerce()
+export const useCommerce = () => useCoreCommerce<LocalProvider>()

--- a/framework/local/provider.ts
+++ b/framework/local/provider.ts
@@ -9,7 +9,6 @@ import { handler as useLogin } from './auth/use-login'
 import { handler as useLogout } from './auth/use-logout'
 import { handler as useSignup } from './auth/use-signup'
 
-export type Provider = typeof localProvider
 export const localProvider = {
   locale: 'en-us',
   cartCookie: 'session',
@@ -19,3 +18,5 @@ export const localProvider = {
   products: { useSearch },
   auth: { useLogin, useLogout, useSignup },
 }
+
+export type LocalProvider = typeof localProvider

--- a/framework/saleor/api/index.ts
+++ b/framework/saleor/api/index.ts
@@ -1,5 +1,5 @@
-import type { CommerceAPIConfig } from '@commerce/api'
-
+import { CommerceAPI, CommerceAPIConfig, getCommerceApi as commerceApi } from '@commerce/api'
+import * as operations from './operations'
 import * as Const from '../const'
 
 if (!Const.API_URL) {
@@ -27,23 +27,12 @@ const config: SaleorConfig = {
   storeChannel: Const.API_CHANNEL,
 }
 
-import {
-  CommerceAPI,
-  getCommerceApi as commerceApi,
-} from '@commerce/api'
-
-import * as operations from './operations'
-
-export interface ShopifyConfig extends CommerceAPIConfig {}
-
 export const provider = { config, operations }
 
 export type Provider = typeof provider
 
 export type SaleorAPI<P extends Provider = Provider> = CommerceAPI<P>
 
-export function getCommerceApi<P extends Provider>(
-  customProvider: P = provider as any
-): SaleorAPI<P> {
+export function getCommerceApi<P extends Provider>(customProvider: P = provider as any): SaleorAPI<P> {
   return commerceApi(customProvider)
 }

--- a/framework/saleor/api/operations/get-all-product-paths.ts
+++ b/framework/saleor/api/operations/get-all-product-paths.ts
@@ -1,10 +1,6 @@
 import type { OperationContext } from '@commerce/api/operations'
-import {
-  GetAllProductPathsQuery,
-  GetAllProductPathsQueryVariables,
-  ProductCountableEdge,
-} from '../../schema'
-import type { ShopifyConfig, Provider, SaleorConfig } from '..'
+import { ProductCountableEdge } from '../../schema'
+import type { Provider, SaleorConfig } from '..'
 
 import { getAllProductsPathsQuery } from '../../utils/queries'
 import fetchAllProducts from '../utils/fetch-all-products'
@@ -13,10 +9,7 @@ export type GetAllProductPathsResult = {
   products: Array<{ path: string }>
 }
 
-export default function getAllProductPathsOperation({
-  commerce,
-}: OperationContext<Provider>) {
-
+export default function getAllProductPathsOperation({ commerce }: OperationContext<Provider>) {
   async function getAllProductPaths({
     query,
     config,
@@ -24,7 +17,7 @@ export default function getAllProductPathsOperation({
   }: {
     query?: string
     config?: SaleorConfig
-    variables?: any 
+    variables?: any
   } = {}): Promise<GetAllProductPathsResult> {
     config = commerce.getConfig(config)
 
@@ -39,7 +32,6 @@ export default function getAllProductPathsOperation({
         path: `/${slug}`,
       })),
     }
-
   }
 
   return getAllProductPaths

--- a/framework/saleor/index.tsx
+++ b/framework/saleor/index.tsx
@@ -1,32 +1,9 @@
-import * as React from 'react'
-import { ReactNode } from 'react'
-
-import { CommerceConfig, CommerceProvider as CoreCommerceProvider, useCommerce as useCoreCommerce } from '@commerce'
-
+import { getCommerceProvider, useCommerce as useCoreCommerce } from '@commerce'
 import { saleorProvider, SaleorProvider } from './provider'
-import * as Const from './const'
 
 export { saleorProvider }
 export type { SaleorProvider }
 
-export const saleorConfig: CommerceConfig = {
-  locale: 'en-us',
-  cartCookie: Const.CHECKOUT_ID_COOKIE,
-}
+export const CommerceProvider = getCommerceProvider(saleorProvider)
 
-export type SaleorConfig = Partial<CommerceConfig>
-
-export type SaleorProps = {
-  children?: ReactNode
-  locale: string
-} & SaleorConfig
-
-export function CommerceProvider({ children, ...config }: SaleorProps) {
-  return (
-    <CoreCommerceProvider provider={saleorProvider} config={{ ...saleorConfig, ...config }}>
-      {children}
-    </CoreCommerceProvider>
-  )
-}
-
-export const useCommerce = () => useCoreCommerce()
+export const useCommerce = () => useCoreCommerce<SaleorProvider>()

--- a/framework/saleor/provider.ts
+++ b/framework/saleor/provider.ts
@@ -1,3 +1,4 @@
+import { CHECKOUT_ID_COOKIE } from './const'
 import { handler as useCart } from './cart/use-cart'
 import { handler as useAddItem } from './cart/use-add-item'
 import { handler as useUpdateItem } from './cart/use-update-item'
@@ -14,8 +15,7 @@ import fetcher from './fetcher'
 
 export const saleorProvider = {
   locale: 'en-us',
-  cartCookie: '',
-  cartCookieToken: '',
+  cartCookie: CHECKOUT_ID_COOKIE,
   fetcher,
   cart: { useCart, useAddItem, useUpdateItem, useRemoveItem },
   customer: { useCustomer },

--- a/framework/shopify/index.tsx
+++ b/framework/shopify/index.tsx
@@ -1,40 +1,10 @@
-import * as React from 'react'
-import { ReactNode } from 'react'
-
-import {
-  CommerceConfig,
-  CommerceProvider as CoreCommerceProvider,
-  useCommerce as useCoreCommerce,
-} from '@commerce'
-
+import { getCommerceProvider, useCommerce as useCoreCommerce } from '@commerce'
 import { shopifyProvider } from './provider'
 import type { ShopifyProvider } from './provider'
-import { SHOPIFY_CHECKOUT_ID_COOKIE } from './const'
 
 export { shopifyProvider }
 export type { ShopifyProvider }
 
-export const shopifyConfig: CommerceConfig = {
-  locale: 'en-us',
-  cartCookie: SHOPIFY_CHECKOUT_ID_COOKIE,
-}
-
-export type ShopifyConfig = Partial<CommerceConfig>
-
-export type ShopifyProps = {
-  children?: ReactNode
-  locale: string
-} & ShopifyConfig
-
-export function CommerceProvider({ children, ...config }: ShopifyProps) {
-  return (
-    <CoreCommerceProvider
-      provider={shopifyProvider}
-      config={{ ...shopifyConfig, ...config }}
-    >
-      {children}
-    </CoreCommerceProvider>
-  )
-}
+export const CommerceProvider = getCommerceProvider(shopifyProvider)
 
 export const useCommerce = () => useCoreCommerce<ShopifyProvider>()

--- a/framework/shopify/index.tsx
+++ b/framework/shopify/index.tsx
@@ -1,6 +1,5 @@
 import { getCommerceProvider, useCommerce as useCoreCommerce } from '@commerce'
-import { shopifyProvider } from './provider'
-import type { ShopifyProvider } from './provider'
+import { shopifyProvider, ShopifyProvider } from './provider'
 
 export { shopifyProvider }
 export type { ShopifyProvider }

--- a/framework/swell/api/utils/fetch-swell-api.ts
+++ b/framework/swell/api/utils/fetch-swell-api.ts
@@ -1,7 +1,7 @@
-import { swellConfig } from '../..'
+import swell from '../../swell'
 
 const fetchApi = async (query: string, method: string, variables: [] = []) => {
-  const { swell } = swellConfig
   return swell[query][method](...variables)
 }
+
 export default fetchApi

--- a/framework/swell/const.ts
+++ b/framework/swell/const.ts
@@ -4,8 +4,6 @@ export const SWELL_CHECKOUT_URL_COOKIE = 'swell_checkoutUrl'
 
 export const SWELL_CUSTOMER_TOKEN_COOKIE = 'swell_customerToken'
 
-export const STORE_DOMAIN = process.env.NEXT_PUBLIC_SWELL_STORE_DOMAIN
-
 export const SWELL_COOKIE_EXPIRE = 30
 
 export const SWELL_STORE_ID = process.env.NEXT_PUBLIC_SWELL_STORE_ID

--- a/framework/swell/fetcher.ts
+++ b/framework/swell/fetcher.ts
@@ -1,11 +1,9 @@
 import { Fetcher } from '@commerce/utils/types'
-import { handleFetchResponse } from './utils'
-import { swellConfig } from './index'
 import { CommerceError } from '@commerce/utils/errors'
+import { handleFetchResponse } from './utils'
+import swell from './swell'
 
 const fetcher: Fetcher = async ({ method = 'get', variables, query }) => {
-  const { swell } = swellConfig
-
   async function callSwell() {
     if (Array.isArray(variables)) {
       const arg1 = variables[0]

--- a/framework/swell/index.tsx
+++ b/framework/swell/index.tsx
@@ -1,47 +1,9 @@
-import * as React from 'react'
-import swell from 'swell-js'
-import { ReactNode } from 'react'
-
-import {
-  CommerceConfig,
-  CommerceProvider as CoreCommerceProvider,
-  useCommerce as useCoreCommerce,
-} from '@commerce'
-
+import { getCommerceProvider, useCommerce as useCoreCommerce } from '@commerce'
 import { swellProvider, SwellProvider } from './provider'
-import {
-  SWELL_CHECKOUT_ID_COOKIE,
-  SWELL_STORE_ID,
-  SWELL_PUBLIC_KEY,
-} from './const'
-swell.init(SWELL_STORE_ID, SWELL_PUBLIC_KEY)
 
 export { swellProvider }
 export type { SwellProvider }
 
-export const swellConfig: any = {
-  locale: 'en-us',
-  cartCookie: SWELL_CHECKOUT_ID_COOKIE,
-  swell,
-}
+export const CommerceProvider = getCommerceProvider(swellProvider)
 
-export type SwellConfig = Partial<CommerceConfig>
-
-export type SwellProps = {
-  children?: ReactNode
-  locale: string
-} & SwellConfig
-
-export function CommerceProvider({ children, ...config }: SwellProps) {
-  return (
-    <CoreCommerceProvider
-      // TODO: Fix this type
-      provider={swellProvider as any}
-      config={{ ...swellConfig, ...config }}
-    >
-      {children}
-    </CoreCommerceProvider>
-  )
-}
-
-export const useCommerce = () => useCoreCommerce()
+export const useCommerce = () => useCoreCommerce<SwellProvider>()

--- a/framework/swell/provider.ts
+++ b/framework/swell/provider.ts
@@ -1,10 +1,5 @@
-import swell from 'swell-js'
 import { Provider } from '@commerce'
-import {
-  SWELL_CHECKOUT_ID_COOKIE,
-  SWELL_STORE_ID,
-  SWELL_PUBLIC_KEY,
-} from './const'
+import { SWELL_CHECKOUT_ID_COOKIE } from './const'
 
 import { handler as useCart } from './cart/use-cart'
 import { handler as useAddItem } from './cart/use-add-item'
@@ -19,8 +14,7 @@ import { handler as useLogout } from './auth/use-logout'
 import { handler as useSignup } from './auth/use-signup'
 
 import fetcher from './fetcher'
-
-swell.init(SWELL_STORE_ID, SWELL_PUBLIC_KEY)
+import swell from './swell'
 
 export const swellProvider: Provider & { swell: any } = {
   locale: 'en-us',

--- a/framework/swell/provider.ts
+++ b/framework/swell/provider.ts
@@ -1,6 +1,10 @@
+import swell from 'swell-js'
 import { Provider } from '@commerce'
-
-import { SWELL_CHECKOUT_URL_COOKIE, STORE_DOMAIN } from './const'
+import {
+  SWELL_CHECKOUT_ID_COOKIE,
+  SWELL_STORE_ID,
+  SWELL_PUBLIC_KEY,
+} from './const'
 
 import { handler as useCart } from './cart/use-cart'
 import { handler as useAddItem } from './cart/use-add-item'
@@ -16,10 +20,12 @@ import { handler as useSignup } from './auth/use-signup'
 
 import fetcher from './fetcher'
 
-export const swellProvider: Provider = {
+swell.init(SWELL_STORE_ID, SWELL_PUBLIC_KEY)
+
+export const swellProvider: Provider & { swell: any } = {
   locale: 'en-us',
-  cartCookie: SWELL_CHECKOUT_URL_COOKIE,
-  // storeDomain: STORE_DOMAIN,
+  cartCookie: SWELL_CHECKOUT_ID_COOKIE,
+  swell,
   fetcher,
   cart: { useCart, useAddItem, useUpdateItem, useRemoveItem },
   customer: { useCustomer },

--- a/framework/swell/swell.ts
+++ b/framework/swell/swell.ts
@@ -1,0 +1,6 @@
+import swell from 'swell-js'
+import { SWELL_STORE_ID, SWELL_PUBLIC_KEY } from './const'
+
+swell.init(SWELL_STORE_ID, SWELL_PUBLIC_KEY)
+
+export default swell

--- a/framework/vendure/index.tsx
+++ b/framework/vendure/index.tsx
@@ -1,33 +1,9 @@
-import * as React from 'react'
-import { ReactNode } from 'react'
-import {
-  CommerceConfig,
-  CommerceProvider as CoreCommerceProvider,
-  useCommerce as useCoreCommerce,
-} from '@commerce'
-import { vendureProvider } from './provider'
+import { getCommerceProvider, useCommerce as useCoreCommerce } from '@commerce'
+import { vendureProvider, VendureProvider } from './provider'
 
-export const vendureConfig: CommerceConfig = {
-  locale: 'en-us',
-  cartCookie: 'session',
-}
+export { vendureProvider }
+export type { VendureProvider }
 
-export type VendureConfig = Partial<CommerceConfig>
-
-export type VendureProps = {
-  children?: ReactNode
-  locale: string
-} & VendureConfig
-
-export function CommerceProvider({ children, ...config }: VendureProps) {
-  return (
-    <CoreCommerceProvider
-      provider={vendureProvider}
-      config={{ ...vendureConfig, ...config }}
-    >
-      {children}
-    </CoreCommerceProvider>
-  )
-}
+export const CommerceProvider = getCommerceProvider(vendureProvider)
 
 export const useCommerce = () => useCoreCommerce()

--- a/framework/vendure/provider.ts
+++ b/framework/vendure/provider.ts
@@ -1,4 +1,3 @@
-import { Provider } from '@commerce'
 import { handler as useCart } from './cart/use-cart'
 import { handler as useAddItem } from './cart/use-add-item'
 import { handler as useUpdateItem } from './cart/use-update-item'
@@ -10,7 +9,7 @@ import { handler as useLogout } from './auth/use-logout'
 import { handler as useSignup } from './auth/use-signup'
 import { fetcher } from './fetcher'
 
-export const vendureProvider: Provider = {
+export const vendureProvider = {
   locale: 'en-us',
   cartCookie: 'session',
   fetcher,
@@ -19,3 +18,5 @@ export const vendureProvider: Provider = {
   products: { useSearch },
   auth: { useLogin, useLogout, useSignup },
 }
+
+export type VendureProvider = typeof vendureProvider


### PR DESCRIPTION
Fixes #236

This PR removes the use of duplicated config when creating a provider. And also improves the way it's created.