### PR TITLE
Fix next/link should be used with anchor as children #330

### DIFF
--- a/components/cart/CartItem/CartItem.tsx
+++ b/components/cart/CartItem/CartItem.tsx
@@ -85,25 +85,29 @@ const CartItem = ({
       <div className="flex flex-row space-x-4 py-4">
         <div className="w-16 h-16 bg-violet relative overflow-hidden cursor-pointer z-0">
           <Link href={`/product/${item.path}`}>
-            <Image
-              onClick={() => closeSidebarIfPresent()}
-              className={s.productImage}
-              width={150}
-              height={150}
-              src={item.variant.image!.url}
-              alt={item.variant.image!.altText}
-              unoptimized
-            />
+            <a>
+              <Image
+                onClick={() => closeSidebarIfPresent()}
+                className={s.productImage}
+                width={150}
+                height={150}
+                src={item.variant.image!.url}
+                alt={item.variant.image!.altText}
+                unoptimized
+              />
+            </a>
           </Link>
         </div>
         <div className="flex-1 flex flex-col text-base">
           <Link href={`/product/${item.path}`}>
-            <span
-              className={s.productName}
-              onClick={() => closeSidebarIfPresent()}
-            >
-              {item.name}
-            </span>
+            <a>
+              <span
+                className={s.productName}
+                onClick={() => closeSidebarIfPresent()}
+              >
+                {item.name}
+              </span>
+            </a>
           </Link>
           {options && options.length > 0 && (
             <div className="flex items-center pb-1">

--- a/components/cart/CartSidebarView/CartSidebarView.tsx
+++ b/components/cart/CartSidebarView/CartSidebarView.tsx
@@ -74,9 +74,11 @@ const CartSidebarView: FC = () => {
         <>
           <div className="px-4 sm:px-6 flex-1">
             <Link href="/cart">
-              <Text variant="sectionHeading" onClick={handleClose}>
-                My Cart
-              </Text>
+              <a>
+                <Text variant="sectionHeading" onClick={handleClose}>
+                  My Cart
+                </Text>
+              </a>
             </Link>
             <ul className={s.lineItemsList}>
               {data!.lineItems.map((item: any) => (

--- a/components/checkout/CheckoutSidebarView/CheckoutSidebarView.tsx
+++ b/components/checkout/CheckoutSidebarView/CheckoutSidebarView.tsx
@@ -35,7 +35,9 @@ const CheckoutSidebarView: FC = () => {
     >
       <div className="px-4 sm:px-6 flex-1">
         <Link href="/cart">
-          <Text variant="sectionHeading">Checkout</Text>
+          <a>
+            <Text variant="sectionHeading">Checkout</Text>
+          </a>
         </Link>
 
         <PaymentWidget onClick={() => setSidebarView('PAYMENT_VIEW')} />


### PR DESCRIPTION
Hi, I'm sending this PR to solve the issue "https://github.com/vercel/commerce/issues/330".

However, as I mentioned in the issue #330 , the problem of clicking and closing instantly is not due to the lack of the <a> tag, but because of the `closeSidebarIfPresent` method added to the click.

In this PR I'm just fixing the accessibility issue by adding the missing tag

Thank you and I'm available


close #330