### PR TITLE
Fix redirect checkout

### DIFF
--- a/framework/bigcommerce/api/endpoints/checkout/get-checkout.ts
+++ b/framework/bigcommerce/api/endpoints/checkout/get-checkout.ts
@@ -5,7 +5,7 @@ import { uuid } from 'uuidv4'
 
 const fullCheckout = true
 
-const submitCheckout: CheckoutEndpoint['handlers']['submitCheckout'] = async ({
+const getCheckout: CheckoutEndpoint['handlers']['getCheckout'] = async ({
   req,
   res,
   config,
@@ -87,4 +87,4 @@ const submitCheckout: CheckoutEndpoint['handlers']['submitCheckout'] = async ({
   res.end()
 }
 
-export default submitCheckout
+export default getCheckout

--- a/framework/bigcommerce/api/endpoints/checkout/index.ts
+++ b/framework/bigcommerce/api/endpoints/checkout/index.ts
@@ -2,13 +2,13 @@ import { GetAPISchema, createEndpoint } from '@commerce/api'
 import checkoutEndpoint from '@commerce/api/endpoints/checkout'
 import type { CheckoutSchema } from '../../../types/checkout'
 import type { BigcommerceAPI } from '../..'
-import submitCheckout from './submit-checkout'
+import getCheckout from './get-checkout'
 
 export type CheckoutAPI = GetAPISchema<BigcommerceAPI, CheckoutSchema>
 
 export type CheckoutEndpoint = CheckoutAPI['endpoint']
 
-export const handlers: CheckoutEndpoint['handlers'] = { submitCheckout }
+export const handlers: CheckoutEndpoint['handlers'] = { getCheckout }
 
 const checkoutApi = createEndpoint<CheckoutAPI>({
   handler: checkoutEndpoint,

--- a/framework/commerce/api/endpoints/checkout.ts
+++ b/framework/commerce/api/endpoints/checkout.ts
@@ -26,11 +26,11 @@ const checkoutEndpoint: GetAPISchema<
     // Create checkout
     if (req.method === 'GET') {
       const body = { ...req.body, cartId }
-      return await handlers['getCheckout']?.({ ...ctx, body })
+      return await handlers['getCheckout']({ ...ctx, body })
     }
 
     // Create checkout
-    if (req.method === 'POST') {
+    if (req.method === 'POST' && handlers['submitCheckout']) {
       const body = { ...req.body, cartId }
       return await handlers['submitCheckout']({ ...ctx, body })
     }

--- a/framework/commerce/types/checkout.ts
+++ b/framework/commerce/types/checkout.ts
@@ -3,7 +3,7 @@ import type { Address } from './customer/address'
 import type { Card } from './customer/card'
 
 // Index
-export type Checkout = unknown;
+export type Checkout = any
 
 export type CheckoutTypes = {
   card?: Card
@@ -45,8 +45,8 @@ export type SubmitCheckoutHandler<T extends CheckoutTypes = CheckoutTypes> =
   }
 
 export type CheckoutHandlers<T extends CheckoutTypes = CheckoutTypes> = {
-  getCheckout?: GetCheckoutHandler<T>
-  submitCheckout: SubmitCheckoutHandler<T>
+  getCheckout: GetCheckoutHandler<T>
+  submitCheckout?: SubmitCheckoutHandler<T>
 }
 
 export type CheckoutSchema<T extends CheckoutTypes = CheckoutTypes> = {

--- a/framework/saleor/api/endpoints/checkout/index.ts
+++ b/framework/saleor/api/endpoints/checkout/index.ts
@@ -6,7 +6,7 @@ export type CheckoutAPI = GetAPISchema<CommerceAPI, CheckoutSchema>
 
 export type CheckoutEndpoint = CheckoutAPI['endpoint']
 
-const submitCheckout: CheckoutEndpoint['handlers']['submitCheckout'] = async ({ req, res, config }) => {
+const getCheckout: CheckoutEndpoint['handlers']['getCheckout'] = async ({ req, res, config }) => {
   try {
     const html = `
       <!DOCTYPE html>
@@ -43,7 +43,7 @@ const submitCheckout: CheckoutEndpoint['handlers']['submitCheckout'] = async ({ 
   }
 }
 
-export const handlers: CheckoutEndpoint['handlers'] = { submitCheckout }
+export const handlers: CheckoutEndpoint['handlers'] = { getCheckout }
 
 const checkoutApi = createEndpoint<CheckoutAPI>({
   handler: checkoutEndpoint,

--- a/framework/saleor/commerce.config.json
+++ b/framework/saleor/commerce.config.json
@@ -1,7 +1,6 @@
 {
   "provider": "saleor",
   "features": {
-    "wishlist": false,
-    "customCheckout": true
+    "wishlist": false
   }
 }

--- a/framework/shopify/api/endpoints/checkout/get-checkout.ts
+++ b/framework/shopify/api/endpoints/checkout/get-checkout.ts
@@ -6,7 +6,7 @@ import {
 import associateCustomerWithCheckoutMutation from '../../../utils/mutations/associate-customer-with-checkout'
 import type { CheckoutEndpoint } from '.'
 
-const submitCheckout: CheckoutEndpoint['handlers']['submitCheckout'] = async ({
+const getCheckout: CheckoutEndpoint['handlers']['getCheckout'] = async ({
   req,
   res,
   config,
@@ -35,4 +35,4 @@ const submitCheckout: CheckoutEndpoint['handlers']['submitCheckout'] = async ({
   }
 }
 
-export default submitCheckout
+export default getCheckout

--- a/framework/shopify/api/endpoints/checkout/index.ts
+++ b/framework/shopify/api/endpoints/checkout/index.ts
@@ -2,13 +2,13 @@ import { GetAPISchema, createEndpoint } from '@commerce/api'
 import checkoutEndpoint from '@commerce/api/endpoints/checkout'
 import type { CheckoutSchema } from '../../../types/checkout'
 import type { ShopifyAPI } from '../..'
-import submitCheckout from './submit-checkout'
+import getCheckout from './get-checkout'
 
 export type CheckoutAPI = GetAPISchema<ShopifyAPI, CheckoutSchema>
 
 export type CheckoutEndpoint = CheckoutAPI['endpoint']
 
-export const handlers: CheckoutEndpoint['handlers'] = { submitCheckout }
+export const handlers: CheckoutEndpoint['handlers'] = { getCheckout }
 
 const checkoutApi = createEndpoint<CheckoutAPI>({
   handler: checkoutEndpoint,

--- a/framework/swell/api/endpoints/checkout/index.ts
+++ b/framework/swell/api/endpoints/checkout/index.ts
@@ -3,7 +3,7 @@ import { CheckoutSchema } from '@commerce/types/checkout'
 import { SWELL_CHECKOUT_URL_COOKIE } from '../../../const'
 import checkoutEndpoint from '@commerce/api/endpoints/checkout'
 
-const submitCheckout: CheckoutEndpoint['handlers']['submitCheckout'] = async ({
+const getCheckout: CheckoutEndpoint['handlers']['getCheckout'] = async ({
   req,
   res,
   config,
@@ -17,7 +17,7 @@ const submitCheckout: CheckoutEndpoint['handlers']['submitCheckout'] = async ({
     res.redirect('/cart')
   }
 }
-export const handlers: CheckoutEndpoint['handlers'] = { submitCheckout }
+export const handlers: CheckoutEndpoint['handlers'] = { getCheckout }
 
 export type CheckoutAPI = GetAPISchema<CommerceAPI, CheckoutSchema>
 export type CheckoutEndpoint = CheckoutAPI['endpoint']

--- a/framework/vendure/api/endpoints/checkout/index.ts
+++ b/framework/vendure/api/endpoints/checkout/index.ts
@@ -3,7 +3,7 @@ import { CommerceAPI, createEndpoint, GetAPISchema } from '@commerce/api'
 import { CheckoutSchema } from '@commerce/types/checkout'
 import checkoutEndpoint from '@commerce/api/endpoints/checkout'
 
-const submitCheckout: CheckoutEndpoint['handlers']['submitCheckout'] = async ({
+const getCheckout: CheckoutEndpoint['handlers']['getCheckout'] = async ({
   req,
   res,
   config,
@@ -48,7 +48,7 @@ export type CheckoutAPI = GetAPISchema<CommerceAPI, CheckoutSchema>
 
 export type CheckoutEndpoint = CheckoutAPI['endpoint']
 
-export const handlers: CheckoutEndpoint['handlers'] = { submitCheckout }
+export const handlers: CheckoutEndpoint['handlers'] = { getCheckout }
 
 const checkoutApi = createEndpoint<CheckoutAPI>({
   handler: checkoutEndpoint,

--- a/next.config.js
+++ b/next.config.js
@@ -19,7 +19,7 @@ module.exports = withCommerceConfig({
   },
   rewrites() {
     return [
-      (isBC || isShopify || isSwell || isVendure) && {
+      (isBC || isShopify || isSwell || isVendure || isSaleor) && {
         source: '/checkout',
         destination: '/api/checkout',
       },


### PR DESCRIPTION
This PR makes `getCheckout` required instead of `submitCheckout` to avoid changes on providers that depends on checkout redirections. Also custom checkout was disabled on saleor until they implement it.