### PR TITLE
Fix: Product Slider Firefox Layout

### DIFF
--- a/components/product/ProductSlider/ProductSlider.module.css
+++ b/components/product/ProductSlider/ProductSlider.module.css
@@ -4,7 +4,7 @@
 }
 
 .slider {
-  @apply relative h-full transition-opacity duration-150;
+  @apply relative transition-opacity duration-150;
   opacity: 0;
 }
 


### PR DESCRIPTION
- Remove height style from product slider component
- Resolves an issue where the product thumbnails aren't shown on Firefox since the height attribute was causing the view to overflow