### PR TITLE
Abstract common static props

### DIFF
--- a/lib/default-props.ts
+++ b/lib/default-props.ts
@@ -7,6 +7,7 @@ import type { Page } from '@commerce/types/page'
 import type { Category } from '@commerce/types/site'
 
 import commerce from '@lib/api/commerce'
+import { ParsedUrlQuery } from 'querystring'
 
 export interface DefaultPageProps {
   pages: Page[]
@@ -14,13 +15,13 @@ export interface DefaultPageProps {
   brand: string
 }
 
-export function withDefaultStaticProps<T = { [key: string | number]: any }>(
+export function withDefaultStaticProps<T, P extends ParsedUrlQuery = any>(
   fn?: ({
     defaultProps,
     ...context
-  }: GetStaticPropsContext & {
+  }: GetStaticPropsContext<P> & {
     defaultProps: DefaultPageProps
-  }) => GetStaticPropsResult<T>
+  }) => GetStaticPropsResult<T> | Promise<GetStaticPropsResult<T>>
 ): GetStaticProps<T & DefaultPageProps> {
   return async function wrapped(context) {
     const config = { locale: context.locale, locales: context.locales }
@@ -69,4 +70,13 @@ export function withDefaultStaticProps<T = { [key: string | number]: any }>(
       },
     }
   }
+}
+
+export function withDefaultSearchStaticProps() {
+  return withDefaultStaticProps(async function () {
+    return {
+      props: {},
+      revalidate: 200,
+    }
+  })
 }

--- a/lib/default-props.ts
+++ b/lib/default-props.ts
@@ -1,4 +1,8 @@
-import { GetStaticProps, GetStaticPropsResult } from 'next'
+import {
+  GetStaticProps,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next'
 import type { Page } from '@commerce/types/page'
 import type { Category } from '@commerce/types/site'
 
@@ -11,7 +15,12 @@ export interface DefaultPageProps {
 }
 
 export function withDefaultStaticProps<T = { [key: string | number]: any }>(
-  fn?: GetStaticProps<T>
+  fn?: ({
+    defaultProps,
+    ...context
+  }: GetStaticPropsContext & {
+    defaultProps: DefaultPageProps
+  }) => GetStaticPropsResult<T>
 ): GetStaticProps<T & DefaultPageProps> {
   return async function wrapped(context) {
     const config = { locale: context.locale, locales: context.locales }
@@ -33,7 +42,10 @@ export function withDefaultStaticProps<T = { [key: string | number]: any }>(
       }
     }
 
-    const pageProps = await fn(context)
+    const pageProps = await fn({
+      ...context,
+      defaultprops: { pages, categories, brand },
+    })
 
     // narrow GetStaticPropsResult type
     if ('props' in pageProps) {

--- a/lib/default-props.ts
+++ b/lib/default-props.ts
@@ -1,0 +1,60 @@
+import { GetStaticProps, GetStaticPropsResult } from 'next'
+import type { Page } from '@commerce/types/page'
+import type { Category } from '@commerce/types/site'
+
+import commerce from '@lib/api/commerce'
+
+export interface DefaultPageProps {
+  pages: Page[]
+  categories: Category[]
+  brand: string
+}
+
+export function withDefaultStaticProps<T = { [key: string | number]: any }>(
+  fn?: GetStaticProps<T>
+): GetStaticProps<T & DefaultPageProps> {
+  return async function wrapped(context) {
+    const config = { locale: context.locale, locales: context.locales }
+    const preview = context.preview
+
+    const pages = await commerce.getAllPages({ config, preview })
+    const { categories, brand } = await commerce.getSiteInfo({
+      config,
+      preview,
+    })
+
+    if (!fn) {
+      return {
+        props: {
+          pages,
+          categories,
+          brand,
+        },
+      }
+    }
+
+    const pageProps = await fn(context)
+
+    // narrow GetStaticPropsResult type
+    if ('props' in pageProps) {
+      return {
+        ...pageProps,
+        props: {
+          ...pageProps.props,
+          pages,
+          categories,
+          brand,
+        },
+      }
+    }
+
+    return {
+      ...pageProps,
+      props: {
+        pages,
+        categories,
+        brand,
+      },
+    }
+  }
+}

--- a/lib/default-props.ts
+++ b/lib/default-props.ts
@@ -7,16 +7,14 @@ import type { Page } from '@commerce/types/page'
 import type { Category } from '@commerce/types/site'
 
 import commerce from '@lib/api/commerce'
-import { ParsedUrlQuery } from 'querystring'
 
 export interface DefaultPageProps {
   pages: Page[]
   categories: Category[]
-  brand: any
+  brands: any[]
 }
 
-interface ContextWithDefaultProps<P extends ParsedUrlQuery = ParsedUrlQuery>
-  extends GetStaticPropsContext<P> {
+interface ContextWithDefaultProps extends GetStaticPropsContext {
   defaultProps: DefaultPageProps
 }
 
@@ -24,18 +22,15 @@ type WrappedGetStaticPropsResult<Q> =
   | GetStaticPropsResult<Q>
   | Promise<GetStaticPropsResult<Q>>
 
-export function withDefaultStaticProps<
-  T,
-  P extends ParsedUrlQuery = ParsedUrlQuery
->(
-  fn?: (context: ContextWithDefaultProps<P>) => WrappedGetStaticPropsResult<T>
+export function withDefaultStaticProps<T>(
+  fn?: (context: ContextWithDefaultProps) => WrappedGetStaticPropsResult<T>
 ): GetStaticProps<T & DefaultPageProps> {
   return async function wrapped(context) {
     const config = { locale: context.locale, locales: context.locales }
     const preview = context.preview
 
     const pages = await commerce.getAllPages({ config, preview })
-    const { categories, brand = null } = await commerce.getSiteInfo({
+    const { categories, brands = [] } = await commerce.getSiteInfo({
       config,
       preview,
     })
@@ -43,7 +38,7 @@ export function withDefaultStaticProps<
     const defaultProps = {
       pages,
       categories,
-      brand,
+      brands,
     }
 
     if (!fn) {
@@ -51,13 +46,12 @@ export function withDefaultStaticProps<
         props: {
           ...pages,
           categories,
-          brand,
+          brands,
         },
       }
     }
 
-    // @ts-ignore
-    // TODO make types compatible
+    // TODO add QueryParam generic
     const pageProps = await fn({
       defaultProps,
       ...context,
@@ -71,7 +65,7 @@ export function withDefaultStaticProps<
           ...pageProps.props,
           ...pages,
           categories,
-          brand,
+          brands,
         },
       }
     }
@@ -81,7 +75,7 @@ export function withDefaultStaticProps<
       props: {
         ...pages,
         categories,
-        brand,
+        brands,
       },
     }
   }

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,25 +1,15 @@
-import type { GetStaticPropsContext } from 'next'
-import commerce from '@lib/api/commerce'
 import { Layout } from '@components/common'
 import { Text } from '@components/ui'
+import { withDefaultStaticProps } from '@lib/default-props'
 
-export async function getStaticProps({
-  preview,
-  locale,
-  locales,
-}: GetStaticPropsContext) {
-  const config = { locale, locales }
-  const { pages } = await commerce.getAllPages({ config, preview })
-  const { categories, brands } = await commerce.getSiteInfo({ config, preview })
-  return {
-    props: {
-      pages,
-      categories,
-      brands,
-    },
-    revalidate: 200,
+export const getStaticProps = withDefaultStaticProps(
+  async function getStaticProps() {
+    return {
+      props: {}, // TODO handle empty props type
+      revalidate: 200,
+    }
   }
-}
+)
 
 export default function NotFound() {
   return (

--- a/pages/[...pages].tsx
+++ b/pages/[...pages].tsx
@@ -12,7 +12,7 @@ import type { Page } from '@commerce/types/page'
 import { useRouter } from 'next/router'
 import { withDefaultStaticProps } from '@lib/default-props'
 
-export const getStaticProps = withDefaultStaticProps(
+export const getStaticProps = withDefaultStaticProps<{ page: any }>(
   async function getStaticProps({
     // TODO fix compatibility
     preview,

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -1,26 +1,12 @@
-import type { GetStaticPropsContext } from 'next'
 import useCart from '@framework/cart/use-cart'
 import usePrice from '@framework/product/use-price'
-import commerce from '@lib/api/commerce'
 import { Layout } from '@components/common'
 import { Button, Text } from '@components/ui'
 import { Bag, Cross, Check, MapPin, CreditCard } from '@components/icons'
 import { CartItem } from '@components/cart'
+import { withDefaultStaticProps } from '@lib/default-props'
 
-export async function getStaticProps({
-  preview,
-  locale,
-  locales,
-}: GetStaticPropsContext) {
-  const config = { locale, locales }
-  const pagesPromise = commerce.getAllPages({ config, preview })
-  const siteInfoPromise = commerce.getSiteInfo({ config, preview })
-  const { pages } = await pagesPromise
-  const { categories } = await siteInfoPromise
-  return {
-    props: { pages, categories },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()
 
 export default function Cart() {
   const error = null

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,36 +4,32 @@ import { ProductCard } from '@components/product'
 import { Grid, Marquee, Hero } from '@components/ui'
 // import HomeAllProductsGrid from '@components/common/HomeAllProductsGrid'
 import type { GetStaticPropsContext, InferGetStaticPropsType } from 'next'
+import { withDefaultStaticProps } from '@lib/default-props'
 
-export async function getStaticProps({
-  preview,
-  locale,
-  locales,
-}: GetStaticPropsContext) {
-  const config = { locale, locales }
-  const productsPromise = commerce.getAllProducts({
-    variables: { first: 6 },
-    config,
+export const getStaticProps = withDefaultStaticProps<{ products: any[] }>(
+  async function getStaticProps({
     preview,
-    // Saleor provider only
-    ...({ featured: true } as any),
-  })
-  const pagesPromise = commerce.getAllPages({ config, preview })
-  const siteInfoPromise = commerce.getSiteInfo({ config, preview })
-  const { products } = await productsPromise
-  const { pages } = await pagesPromise
-  const { categories, brands } = await siteInfoPromise
+    locale,
+    locales,
+  }: GetStaticPropsContext) {
+    const config = { locale, locales }
+    const productsPromise = commerce.getAllProducts({
+      variables: { first: 6 },
+      config,
+      preview,
+      // Saleor provider only
+      ...({ featured: true } as any),
+    })
+    const { products } = await productsPromise
 
-  return {
-    props: {
-      products,
-      categories,
-      brands,
-      pages,
-    },
-    revalidate: 60,
+    return {
+      props: {
+        products,
+      },
+      revalidate: 60,
+    }
   }
-}
+)
 
 export default function Home({
   products,

--- a/pages/orders.tsx
+++ b/pages/orders.tsx
@@ -1,24 +1,9 @@
-import type { GetStaticPropsContext } from 'next'
-import commerce from '@lib/api/commerce'
 import { Bag } from '@components/icons'
 import { Layout } from '@components/common'
 import { Container, Text } from '@components/ui'
+import { withDefaultStaticProps } from '@lib/default-props'
 
-export async function getStaticProps({
-  preview,
-  locale,
-  locales,
-}: GetStaticPropsContext) {
-  const config = { locale, locales }
-  const pagesPromise = commerce.getAllPages({ config, preview })
-  const siteInfoPromise = commerce.getSiteInfo({ config, preview })
-  const { pages } = await pagesPromise
-  const { categories } = await siteInfoPromise
-
-  return {
-    props: { pages, categories },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()
 
 export default function Orders() {
   return (

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -7,16 +7,16 @@ import { useRouter } from 'next/router'
 import commerce from '@lib/api/commerce'
 import { Layout } from '@components/common'
 import { ProductView } from '@components/product'
+import { withDefaultStaticProps } from '@lib/default-props'
 
-export async function getStaticProps({
-  params,
-  locale,
-  locales,
-  preview,
-}: GetStaticPropsContext<{ slug: string }>) {
+export const getStaticProps = withDefaultStaticProps<
+  {
+    product: any
+    relatedProducts: any
+  },
+  { slug: string }
+>(async function getStaticProps({ params, locale, locales, preview }) {
   const config = { locale, locales }
-  const pagesPromise = commerce.getAllPages({ config, preview })
-  const siteInfoPromise = commerce.getSiteInfo({ config, preview })
   const productPromise = commerce.getProduct({
     variables: { slug: params!.slug },
     config,
@@ -28,8 +28,6 @@ export async function getStaticProps({
     config,
     preview,
   })
-  const { pages } = await pagesPromise
-  const { categories } = await siteInfoPromise
   const { product } = await productPromise
   const { products: relatedProducts } = await allProductsPromise
 
@@ -39,14 +37,12 @@ export async function getStaticProps({
 
   return {
     props: {
-      pages,
       product,
       relatedProducts,
-      categories,
     },
     revalidate: 200,
   }
-}
+})
 
 export async function getStaticPaths({ locales }: GetStaticPathsContext) {
   const { products } = await commerce.getAllProductPaths()

--- a/pages/product/[slug].tsx
+++ b/pages/product/[slug].tsx
@@ -1,8 +1,4 @@
-import type {
-  GetStaticPathsContext,
-  GetStaticPropsContext,
-  InferGetStaticPropsType,
-} from 'next'
+import type { GetStaticPathsContext, InferGetStaticPropsType } from 'next'
 import { useRouter } from 'next/router'
 import commerce from '@lib/api/commerce'
 import { Layout } from '@components/common'

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,24 +1,9 @@
-import type { GetStaticPropsContext } from 'next'
 import useCustomer from '@framework/customer/use-customer'
-import commerce from '@lib/api/commerce'
 import { Layout } from '@components/common'
 import { Container, Text } from '@components/ui'
+import { withDefaultStaticProps } from '@lib/default-props'
 
-export async function getStaticProps({
-  preview,
-  locale,
-  locales,
-}: GetStaticPropsContext) {
-  const config = { locale, locales }
-  const pagesPromise = commerce.getAllPages({ config, preview })
-  const siteInfoPromise = commerce.getSiteInfo({ config, preview })
-  const { pages } = await pagesPromise
-  const { categories } = await siteInfoPromise
-
-  return {
-    props: { pages, categories },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()
 
 export default function Profile() {
   const { data } = useCustomer()

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,12 +1,6 @@
-import { getSearchStaticProps } from '@lib/search-props'
-import type { GetStaticPropsContext } from 'next'
 import Search from '@components/search'
-import { withDefaultStaticProps } from '@lib/default-props'
+import { withDefaultSearchStaticProps } from '@lib/default-props'
 
-export const getStaticProps = withDefaultStaticProps(
-  async function getStaticProps(context: GetStaticPropsContext) {
-    return getSearchStaticProps(context)
-  }
-)
+export const getStaticProps = withDefaultSearchStaticProps()
 
 export default Search

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,9 +1,12 @@
 import { getSearchStaticProps } from '@lib/search-props'
 import type { GetStaticPropsContext } from 'next'
 import Search from '@components/search'
+import { withDefaultStaticProps } from '@lib/default-props'
 
-export async function getStaticProps(context: GetStaticPropsContext) {
-  return getSearchStaticProps(context)
-}
+export const getStaticProps = withDefaultStaticProps(
+  async function getStaticProps(context: GetStaticPropsContext) {
+    return getSearchStaticProps(context)
+  }
+)
 
 export default Search

--- a/pages/search/[category].tsx
+++ b/pages/search/[category].tsx
@@ -1,10 +1,8 @@
-import { getSearchStaticProps } from '@lib/search-props'
-import type { GetStaticPathsResult, GetStaticPropsContext } from 'next'
+import type { GetStaticPathsResult } from 'next'
 import Search from '@components/search'
+import { withDefaultSearchStaticProps } from '@lib/default-props'
 
-export async function getStaticProps(context: GetStaticPropsContext) {
-  return getSearchStaticProps(context)
-}
+export const getStaticProps = withDefaultSearchStaticProps()
 
 export function getStaticPaths(): GetStaticPathsResult {
   return {

--- a/pages/search/designers/[name].tsx
+++ b/pages/search/designers/[name].tsx
@@ -1,10 +1,8 @@
-import { getSearchStaticProps } from '@lib/search-props'
-import type { GetStaticPathsResult, GetStaticPropsContext } from 'next'
+import type { GetStaticPathsResult } from 'next'
 import Search from '@components/search'
+import { withDefaultSearchStaticProps } from '@lib/default-props'
 
-export async function getStaticProps(context: GetStaticPropsContext) {
-  return getSearchStaticProps(context)
-}
+export const getStaticProps = withDefaultSearchStaticProps()
 
 export function getStaticPaths(): GetStaticPathsResult {
   return {

--- a/pages/search/designers/[name]/[category].tsx
+++ b/pages/search/designers/[name]/[category].tsx
@@ -1,10 +1,8 @@
-import { getSearchStaticProps } from '@lib/search-props'
-import type { GetStaticPathsResult, GetStaticPropsContext } from 'next'
+import type { GetStaticPathsResult } from 'next'
 import Search from '@components/search'
+import { withDefaultSearchStaticProps } from '@lib/default-props'
 
-export async function getStaticProps(context: GetStaticPropsContext) {
-  return getSearchStaticProps(context)
-}
+export const getStaticProps = withDefaultSearchStaticProps()
 
 export function getStaticPaths(): GetStaticPathsResult {
   return {

--- a/pages/wishlist.tsx
+++ b/pages/wishlist.tsx
@@ -1,5 +1,3 @@
-import type { GetStaticPropsContext } from 'next'
-import commerce from '@lib/api/commerce'
 import { Heart } from '@components/icons'
 import { Layout } from '@components/common'
 import { Text, Container, Skeleton } from '@components/ui'
@@ -7,32 +5,9 @@ import { useCustomer } from '@framework/customer'
 import { WishlistCard } from '@components/wishlist'
 import useWishlist from '@framework/wishlist/use-wishlist'
 import rangeMap from '@lib/range-map'
+import { withDefaultStaticProps } from '@lib/default-props'
 
-export async function getStaticProps({
-  preview,
-  locale,
-  locales,
-}: GetStaticPropsContext) {
-  // Disabling page if Feature is not available
-  if (!process.env.COMMERCE_WISHLIST_ENABLED) {
-    return {
-      notFound: true,
-    }
-  }
-
-  const config = { locale, locales }
-  const pagesPromise = commerce.getAllPages({ config, preview })
-  const siteInfoPromise = commerce.getSiteInfo({ config, preview })
-  const { pages } = await pagesPromise
-  const { categories } = await siteInfoPromise
-
-  return {
-    props: {
-      pages,
-      categories,
-    },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()
 
 export default function Wishlist() {
   const { data: customer } = useCustomer()


### PR DESCRIPTION
I have added a wrapper for the `getStaticProps` function that adds all the pages common props and expands the `context` object with those defaults.

## Goal
The main purpose of this PR is to centralize the common props handling in order to ensure a correct implementation across all the project.

- [x] fix some types of the wrapper