### PR TITLE
Added two extensions to VSCode's extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["esbenp.prettier-vscode"]
+  "recommendations": ["esbenp.prettier-vscode", "csstools.postcss", "bradlc.vscode-tailwindcss"]
 }


### PR DESCRIPTION
As I got started with a clone of this repo, I realised I didn't have the [`PostCSS Language Support`](https://marketplace.visualstudio.com/items?itemName=csstools.postcss) and [`Tailwind CSS IntelliSensePreview`](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) extensions installed on my VS Code.

Since this project relies on Tailwind and its `@apply` notation quite a lot, I thought it would be beneficial to add them into the recommended extensions array for VS Code.