### PR TITLE
Make wishlist's useRemoveItem call in WishlistCard consistent with WishlistButton

### DIFF
--- a/components/wishlist/WishlistCard/WishlistCard.tsx
+++ b/components/wishlist/WishlistCard/WishlistCard.tsx
@@ -11,14 +11,16 @@ import type { Product } from '@commerce/types/product'
 import usePrice from '@framework/product/use-price'
 import useAddItem from '@framework/cart/use-add-item'
 import useRemoveItem from '@framework/wishlist/use-remove-item'
+import { Wishlist } from '@commerce/types/wishlist'
 
 interface Props {
-  product: Product
+  item: Wishlist
 }
 
 const placeholderImg = '/product-img-placeholder.svg'
 
-const WishlistCard: FC<Props> = ({ product }) => {
+const WishlistCard: FC<Props> = ({ item }) => {
+  const product: Product = item.product
   const { price } = usePrice({
     amount: product.price?.value,
     baseAmount: product.price?.retailPrice,
@@ -40,7 +42,7 @@ const WishlistCard: FC<Props> = ({ product }) => {
     try {
       // If this action succeeds then there's no need to do `setRemoving(true)`
       // because the component will be removed from the view
-      await removeItem({ id: product.id! })
+      await removeItem({ id: item.id! })
     } catch (error) {
       setRemoving(false)
     }

--- a/pages/wishlist.tsx
+++ b/pages/wishlist.tsx
@@ -69,7 +69,7 @@ export default function Wishlist() {
               {data &&
                 // @ts-ignore Shopify - Fix this types
                 data.items?.map((item) => (
-                  <WishlistCard key={item.id} product={item.product! as any} />
+                  <WishlistCard key={item.id} item={item!} />
                 ))}
             </div>
           )}


### PR DESCRIPTION
In `WishlistCard`, the remove wishlist item hook is called like so: https://github.com/vercel/commerce/blob/main/components/wishlist/WishlistCard/WishlistCard.tsx#L43. *The `id` value contains the id of the product.*

This is how the remove hook is called in `WishlistButton`: https://github.com/vercel/commerce/blob/main/components/wishlist/WishlistButton/WishlistButton.tsx#L53. *The `id` value is the wishlist item's id.*

While the `Wishlist` type is currently `any` (https://github.com/vercel/commerce/blob/main/framework/commerce/types/wishlist.ts#L2), I think the best approach is to agree the value of `id` to be the id of the wishlist item and not the product it's associated with. It's how it already works in `WishlistButton` and in https://github.com/vercel/commerce/blob/main/components/wishlist/WishlistButton/WishlistButton.tsx#L34 a separate `product_id` field is referenced.

The above means changing how `WishlistCard` calls the remove hook. The PR contains this change.