### PR TITLE
Fix typo and add missing feature to local config

### DIFF
--- a/components/checkout/CheckoutSidebarView/CheckoutSidebarView.tsx
+++ b/components/checkout/CheckoutSidebarView/CheckoutSidebarView.tsx
@@ -93,7 +93,7 @@ const CheckoutSidebarView: FC = () => {
           <span>{total}</span>
         </div>
         <div>
-          {/* Once data is correcly filled */}
+          {/* Once data is correctly filled */}
           <Button
             type="submit"
             width="100%"

--- a/framework/local/commerce.config.json
+++ b/framework/local/commerce.config.json
@@ -4,6 +4,7 @@
     "wishlist": false,
     "cart": false,
     "search": false,
-    "customerAuth": false
+    "customerAuth": false,
+    "customCheckout": false
   }
 }


### PR DESCRIPTION
1. Fixes a tiny typo
2. Adds the `customCheckout` feature to the list of features in local provider config

@goncy I think you also mentioned that I fixed a type in https://github.com/vercel/commerce/pull/546 but I have not included that here because actually that type change was specifically for the checkout enhancements, and isn't necessarily aligned with other types (all `GetSomethingHook` hooks have an `input: {}` type so I've left `GetCheckoutHook` the same).