### PR TITLE
Fix BigCommerce Checkout SSO redirect_to issue

### DIFF
--- a/framework/bigcommerce/api/endpoints/checkout/get-checkout.ts
+++ b/framework/bigcommerce/api/endpoints/checkout/get-checkout.ts
@@ -42,7 +42,7 @@ const getCheckout: CheckoutEndpoint['handlers']['getCheckout'] = async ({
       store_hash: config.storeHash,
       customer_id: customerId,
       channel_id: config.storeChannelId,
-      redirect_to: data.checkout_url,
+      redirect_to: data.checkout_url.replace(config.storeUrl, ""),
     }
     let token = jwt.sign(payload, config.storeApiClientSecret!, {
       algorithm: 'HS256',


### PR DESCRIPTION
### Issue
When using the BigCommerce integration, Customer Logins are not maintained when proceeding to the redirected checkout. This is because the **redirect_to** parameter when generating the Customer JWT is using an absolute URL when the API only allows relative paths. 

### Fix
In **framework/bigcommerce/api/endpoints/checkout/get-checkout.ts** on line 45, the **redirect_to** parameter is this currently:
```tsx
redirect_to: data.checkout_url,
```
But needs to be replaced with this:
```tsx
redirect_to: data.checkout_url.replace(config.storeUrl, ""),
```

After making this change, the BigCommerce redirected checkout maintains the customer login session.