### PR TITLE
fix(kibocommerce customer endpoint): check if shopper is anonymous before calling kibo api

### DIFF
--- a/framework/kibocommerce/api/endpoints/customer/customer.ts
+++ b/framework/kibocommerce/api/endpoints/customer/customer.ts
@@ -11,7 +11,7 @@ const getLoggedInCustomer: CustomerEndpoint['handlers']['getLoggedInCustomer'] =
   const cookieHandler = new CookieHandler(config, req, res)
   let accessToken = cookieHandler.getAccessToken();
 
-  if (cookieHandler.getAccessToken()) {
+  if (!cookieHandler.isShopperCookieAnonymous()) {
     const { data } = await config.fetch(getCustomerAccountQuery, undefined, {
       headers: {
         'x-vol-user-claims': accessToken,


### PR DESCRIPTION
Use the stored customer cookie to determine if the shopper is anonymous (not logged in) and only call Kibo API to get customer when shopper is logged in. If the shopper is anonymous, return 200 response to avoid retries from swr hooks.
 
@goncy 