### PR TITLE
avoid malformed url with vendure

### DIFF
--- a/framework/vendure/utils/normalize.ts
+++ b/framework/vendure/utils/normalize.ts
@@ -9,7 +9,13 @@ export function normalizeSearchResult(item: SearchResultFragment): Product {
     description: item.description,
     slug: item.slug,
     path: item.slug,
-    images: [{ url: item.productAsset?.preview + '?w=800&mode=crop' || '' }],
+    images: [
+      {
+        url: item.productAsset?.preview
+          ? item.productAsset?.preview + '?w=800&mode=crop'
+          : '',
+      },
+    ],
     variants: [],
     price: {
       value: (item.priceWithTax as any).min / 100,


### PR DESCRIPTION
The url should be an empty string if `item.productAsset.preview` is undefined, instead of only the search query part, as it crashes when passed to an `<Image />` as src.