### PR TITLE
#629: Conversion of type 'Global & typeof globalThis' to type 'CustomNodeJsGlobal' may be a mistake

### DIFF
--- a/framework/ordercloud/api/utils/fetch-rest.ts
+++ b/framework/ordercloud/api/utils/fetch-rest.ts
@@ -144,7 +144,7 @@ export const createBuyerFetcher: (
     body?: Record<string, unknown>,
     fetchOptions?: Record<string, any>
   ) => {
-    const customGlobal = global as CustomNodeJsGlobal;
+    const customGlobal = global as unknown as CustomNodeJsGlobal;
 
     // Get provider config
     const config = getConfig()


### PR DESCRIPTION
Issue #629 still not fixed. This error did not stop me from running `npm run build` locally but it failed on the vercel build. 

![image](https://user-images.githubusercontent.com/38010640/148252765-5a7cafe6-f612-45ec-ab76-6405472e6245.png)
