### PR TITLE
Default tsconfig framework path to local.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,8 +24,8 @@
       "@components/*": ["components/*"],
       "@commerce": ["framework/commerce"],
       "@commerce/*": ["framework/commerce/*"],
-      "@framework": ["framework/shopify"],
-      "@framework/*": ["framework/shopify/*"]
+      "@framework": ["framework/local"],
+      "@framework/*": ["framework/local/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.d.ts", "**/*.ts", "**/*.tsx", "**/*.js"],


### PR DESCRIPTION
Testing locally it seems that `local` is what's used when there aren't any environment variables configured.

I'm making this change because `next-live` doesn't currently support `fs` functions and therefore cannot update the `paths[@framework]` in next.config.js.  This means deploying the commerce template from `vercel.com/live` generates an error instead of displaying the commerce page as would be displayed when running `npm run dev` locally or deploying to vercel without configuring additional environment variables.