### PR TITLE
Log Spree requests and errors

### DIFF
--- a/framework/spree/api/utils/create-api-fetch.ts
+++ b/framework/spree/api/utils/create-api-fetch.ts
@@ -11,6 +11,7 @@ import createCustomizedFetchFetcher, {
 } from '../../utils/create-customized-fetch-fetcher'
 import fetch, { Request } from 'node-fetch'
 import type { SpreeSdkResponseWithRawResponse } from '../../types'
+import prettyPrintSpreeSdkErrors from '../../utils/pretty-print-spree-sdk-errors'
 
 export type CreateApiFetch = (
   getConfig: () => SpreeApiConfig
@@ -69,6 +70,12 @@ const createApiFetch: CreateApiFetch = (_getConfig) => {
     const storeResponseError = storeResponse.fail()
 
     if (storeResponseError instanceof errors.SpreeError) {
+      console.error(
+        `Request to spree resulted in an error:\n\n${prettyPrintSpreeSdkErrors(
+          storeResponse.fail()
+        )}`
+      )
+
       throw convertSpreeErrorToGraphQlError(storeResponseError)
     }
 

--- a/framework/spree/fetcher.ts
+++ b/framework/spree/fetcher.ts
@@ -16,6 +16,7 @@ import createCustomizedFetchFetcher, {
 } from './utils/create-customized-fetch-fetcher'
 import ensureFreshUserAccessToken from './utils/tokens/ensure-fresh-user-access-token'
 import RefreshTokenError from './errors/RefreshTokenError'
+import prettyPrintSpreeSdkErrors from './utils/pretty-print-spree-sdk-errors'
 
 const client = makeClient({
   host: requireConfigValue('apiHost') as string,
@@ -107,6 +108,12 @@ const fetcher: Fetcher<GraphQLFetcherResult<SpreeSdkResponse>> = async (
   }
 
   if (storeResponseError instanceof errors.SpreeError) {
+    console.error(
+      `Request to spree resulted in an error:\n\n${prettyPrintSpreeSdkErrors(
+        storeResponse.fail()
+      )}`
+    )
+
     throw convertSpreeErrorToGraphQlError(storeResponseError)
   }
 

--- a/framework/spree/utils/create-customized-fetch-fetcher.ts
+++ b/framework/spree/utils/create-customized-fetch-fetcher.ts
@@ -50,6 +50,10 @@ const createCustomizedFetchFetcher: CreateCustomizedFetchFetcher = (
         )
 
         try {
+          console.info(
+            `Calling the Spree API: ${request.method} ${request.url}`
+          )
+
           const response: Response = await fetch(request)
           const responseContentType = response.headers.get('content-type')
           let data

--- a/framework/spree/utils/pretty-print-spree-sdk-errors.ts
+++ b/framework/spree/utils/pretty-print-spree-sdk-errors.ts
@@ -1,0 +1,21 @@
+import { errors } from '@spree/storefront-api-v2-sdk'
+
+const prettyPrintSpreeSdkErrors = (error: errors.SpreeSDKError): string => {
+  let prettyOutput = `Name: ${error.name}\nMessage: ${error.message}`
+
+  if (error instanceof errors.BasicSpreeError) {
+    prettyOutput += `\nSpree summary: ${error.summary}`
+
+    if (error instanceof errors.ExpandedSpreeError) {
+      prettyOutput += `\nSpree validation errors:\n${JSON.stringify(
+        error.errors,
+        null,
+        2
+      )}`
+    }
+  }
+
+  return prettyOutput
+}
+
+export default prettyPrintSpreeSdkErrors


### PR DESCRIPTION
Logs extra information about requests submitted to Spree (when using the Spree framework/provider).

This includes the URL and HTTP method of each request and details about returned errors. With regards to errors, the Spree framework already throws JavaScript `Error` objects. However, the default behaviour in Node and web browsers is to print the standard `name`, `message` and `stack` fields. The Spree SDK can provide more information such as validation issues. This pull request prints those also.