### PR TITLE
Fix BigCommerce limit on product variants

### DIFF
--- a/packages/bigcommerce/src/api/fragments/product.ts
+++ b/packages/bigcommerce/src/api/fragments/product.ts
@@ -58,7 +58,7 @@ export const productInfoFragment = /* GraphQL */ `
         }
       }
     }
-    variants {
+    variants(first: 250) {
       edges {
         node {
           entityId

--- a/packages/bigcommerce/src/api/operations/get-product.ts
+++ b/packages/bigcommerce/src/api/operations/get-product.ts
@@ -21,7 +21,7 @@ export const getProductQuery = /* GraphQL */ `
           __typename
           ... on Product {
             ...productInfo
-            variants {
+            variants(first: 250) {
               edges {
                 node {
                   entityId


### PR DESCRIPTION
This PR is a temporary fix for #303 and #386.

This adds an explicit limit of 250 product variants to the BigCommerce `getProduct` query to avoid issues with products with more than 10 variants. The explicit limit is set to 250 as it seems to be the current maximum limit for the GraphQL query.

Please note that BigCommerce has a limit of 600 variants so a better solution would be to get all variants through pagination:
https://support.bigcommerce.com/s/article/Product-Options-v3?language=en_US#multiple-choice

> A single product can have a maximum of 600 SKUs/variants. If your product has more than 600 variations, we recommend using a modifier option.

Despite this I think this quick fix is worth merging to fix stores with less than 250 variants.