### PR TITLE
Fix turborepo caching edge case 

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,13 @@
       "outputs": ["dist/**"]
     },
     "next-commerce#build": {
-      "dependsOn": ["^build", "$COMMERCE_PROVIDER"],
+      "dependsOn": [
+        "^build",
+        "$COMMERCE_PROVIDER",
+        "$BIGCOMMERCE_STOREFRONT_API_URL",
+        "$NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN",
+        "$NEXT_PUBLIC_SWELL_STORE_ID"
+      ],
       "outputs": [".next/**"]
     },
     "test": {


### PR DESCRIPTION
The cache currently depends on the `COMMERCE_PROVIDER` env var, however I went through the import flow of Next.js Commerce again and it failed because our org already has the build cached, and that's okay but because the provider env isn't set then it's getting the output of the `local` provider. With this PR the cache now includes all the envs we use for package detection when `COMMERCE_PROVIDER` isn't set.