### PR TITLE
Add lodash.debounce to Shopify provider package.json dependencies

### DIFF
--- a/packages/commercejs/package.json
+++ b/packages/commercejs/package.json
@@ -48,7 +48,8 @@
   },
   "dependencies": {
     "@chec/commerce.js": "^2.8.0",
-    "@vercel/commerce": "^0.0.1"
+    "@vercel/commerce": "^0.0.1",
+    "lodash.debounce": "^4.0.8"
   },
   "peerDependencies": {
     "next": "^12",
@@ -60,6 +61,7 @@
     "@taskr/esnext": "^1.1.0",
     "@taskr/watch": "^1.1.0",
     "@types/chec__commerce.js": "^2.8.4",
+    "@types/lodash.debounce": "^4.0.6",
     "@types/node": "^17.0.8",
     "@types/react": "^17.0.38",
     "lint-staged": "^12.1.7",

--- a/packages/kibocommerce/package.json
+++ b/packages/kibocommerce/package.json
@@ -50,7 +50,8 @@
   },
   "dependencies": {
     "@vercel/commerce": "^0.0.1",
-    "@vercel/fetch": "^6.1.1"
+    "@vercel/fetch": "^6.1.1",
+    "lodash.debounce": "^4.0.8"
   },
   "peerDependencies": {
     "next": "^12",
@@ -65,6 +66,7 @@
     "@taskr/clear": "^1.1.0",
     "@taskr/esnext": "^1.1.0",
     "@taskr/watch": "^1.1.0",
+    "@types/lodash.debounce": "^4.0.6",
     "@types/node": "^17.0.8",
     "@types/react": "^17.0.38",
     "lint-staged": "^12.1.7",

--- a/packages/ordercloud/package.json
+++ b/packages/ordercloud/package.json
@@ -49,7 +49,8 @@
   "dependencies": {
     "@vercel/commerce": "^0.0.1",
     "@vercel/fetch": "^6.1.1",
-    "stripe": "^8.197.0"
+    "stripe": "^8.197.0",
+    "lodash.debounce": "^4.0.8"
   },
   "peerDependencies": {
     "next": "^12",
@@ -60,6 +61,7 @@
     "@taskr/clear": "^1.1.0",
     "@taskr/esnext": "^1.1.0",
     "@taskr/watch": "^1.1.0",
+    "@types/lodash.debounce": "^4.0.6",
     "@types/node": "^17.0.8",
     "@types/react": "^17.0.38",
     "lint-staged": "^12.1.7",

--- a/packages/saleor/package.json
+++ b/packages/saleor/package.json
@@ -50,7 +50,8 @@
   },
   "dependencies": {
     "@vercel/commerce": "^0.0.1",
-    "@vercel/fetch": "^6.1.1"
+    "@vercel/fetch": "^6.1.1",
+    "lodash.debounce": "^4.0.8"
   },
   "peerDependencies": {
     "next": "^12",
@@ -65,6 +66,7 @@
     "@taskr/clear": "^1.1.0",
     "@taskr/esnext": "^1.1.0",
     "@taskr/watch": "^1.1.0",
+    "@types/lodash.debounce": "^4.0.6",
     "@types/node": "^17.0.8",
     "@types/react": "^17.0.38",
     "lint-staged": "^12.1.7",

--- a/packages/shopify/package.json
+++ b/packages/shopify/package.json
@@ -66,6 +66,7 @@
     "@taskr/clear": "^1.1.0",
     "@taskr/esnext": "^1.1.0",
     "@taskr/watch": "^1.1.0",
+    "@types/lodash.debounce": "^4.0.6",
     "@types/node": "^17.0.8",
     "@types/react": "^17.0.38",
     "dotenv": "^12.0.3",

--- a/packages/shopify/package.json
+++ b/packages/shopify/package.json
@@ -50,7 +50,8 @@
   },
   "dependencies": {
     "@vercel/commerce": "^0.0.1",
-    "@vercel/fetch": "^6.1.1"
+    "@vercel/fetch": "^6.1.1",
+    "lodash.debounce": "^4.0.8"
   },
   "peerDependencies": {
     "next": "^12",

--- a/packages/spree/package.json
+++ b/packages/spree/package.json
@@ -50,7 +50,8 @@
     "@spree/storefront-api-v2-sdk": "^5.1.1",
     "@vercel/commerce": "^0.0.1",
     "@vercel/fetch": "^6.1.1",
-    "swr": "^1.2.0"
+    "swr": "^1.2.0",
+    "lodash.debounce": "^4.0.8"
   },
   "peerDependencies": {
     "next": "^12",
@@ -61,6 +62,7 @@
     "@taskr/clear": "^1.1.0",
     "@taskr/esnext": "^1.1.0",
     "@taskr/watch": "^1.1.0",
+    "@types/lodash.debounce": "^4.0.6",
     "@types/node": "^17.0.8",
     "@types/react": "^17.0.38",
     "lint-staged": "^12.1.7",

--- a/packages/swell/package.json
+++ b/packages/swell/package.json
@@ -50,7 +50,8 @@
   "dependencies": {
     "@vercel/commerce": "^0.0.1",
     "@vercel/fetch": "^6.1.1",
-    "swell-js": "^4.0.0-next.0"
+    "swell-js": "^4.0.0-next.0",
+    "lodash.debounce": "^4.0.8"
   },
   "peerDependencies": {
     "next": "^12",
@@ -61,6 +62,7 @@
     "@taskr/clear": "^1.1.0",
     "@taskr/esnext": "^1.1.0",
     "@taskr/watch": "^1.1.0",
+    "@types/lodash.debounce": "^4.0.6",
     "@types/node": "^17.0.8",
     "@types/react": "^17.0.38",
     "lint-staged": "^12.1.7",


### PR DESCRIPTION
Shopify provider requires `lodash.debounce` package. This package is installed in BigCommerce provider, but not in Shopify provider. After BigCommerce is removed, Shopfify provider can't be installed.

This PR fixes this error