### PR TITLE
Add README instructions for Vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Follow our docs for [Adding a new Commerce Provider](packages/commerce/new-provi
 
 If you succeeded building a provider, submit a PR with a valid demo and we'll review it asap.
 
+## Deploying to Vercel
+Once you have forked this repo, you can deploy your own version on Vercel. Create a [new project](https://vercel.com/new) by importing your GitHub repository and configuring some Build and Output Settings:
+1. Choose `Next.js` for the framework preset
+2. Set the build command to `yarn build`
+3. Set the output directory to `site/.next` 
+
 ## Contribute
 
 Our commitment to Open Source can be found [here](https://vercel.com/oss).


### PR DESCRIPTION
Since migrating to Turborepo, it seems that deploying to Vercel requires some "Build and Output" configuration extra steps but these aren't documented anywhere. This is what worked for me.

There are a few issues already:
https://github.com/vercel/commerce/issues/688
https://github.com/vercel/commerce/issues/672

Screenshot of my Vercel dashboard (which is now working):
<img width="500" alt="Screenshot 2565-02-21 at 16 54 18" src="https://user-images.githubusercontent.com/35846795/154933483-33d843f3-894b-4253-96e9-ca4df80e0fdd.png">

