### PR TITLE
fix(vendure): add new image domain

### DIFF
--- a/packages/vendure/src/next.config.cjs
+++ b/packages/vendure/src/next.config.cjs
@@ -3,6 +3,6 @@ const commerce = require('./commerce.config.json')
 module.exports = {
   commerce,
   images: {
-    domains: ['localhost', 'demo.vendure.io'],
+    domains: ['localhost', 'demo.vendure.io','readonlydemo.vendure.io'],
   },
 }


### PR DESCRIPTION
As a result, all checks should be green after this PR.

I also changed `NEXT_PUBLIC_VENDURE_SHOP_API_URL` ENV variable on `Vendure` to use the correct domain instead of IP address

