### PR TITLE
Bug: Visual Regressions

### DIFF
--- a/site/components/product/ProductTag/ProductTag.module.css
+++ b/site/components/product/ProductTag/ProductTag.module.css
@@ -27,4 +27,5 @@
 .root .price {
   @apply pt-2 px-6 pb-4 text-sm bg-primary text-accent-9
   font-semibold inline-block tracking-wide;
+  margin-top: -1px;
 }

--- a/site/components/product/ProductTag/ProductTag.module.css
+++ b/site/components/product/ProductTag/ProductTag.module.css
@@ -7,7 +7,7 @@
   @apply pt-0 max-w-full w-full leading-extra-loose;
   font-size: 2rem;
   letter-spacing: 0.4px;
-  line-height: 2.2em;
+  line-height: 2.1em;
 }
 
 .root .name span {


### PR DESCRIPTION
- Fixes offset for PriceTags

Before:
<img width="604" alt="Screenshot 2022-03-02 at 12 39 48" src="https://user-images.githubusercontent.com/1570963/156363233-de2054a9-3c0e-489e-82d8-44e7040fc7c1.png">

After:
<img width="562" alt="Screenshot 2022-03-02 at 12 39 57" src="https://user-images.githubusercontent.com/1570963/156363260-71c27bbb-6933-4211-b062-bb07b951b215.png">



