### PR TITLE
Fix navigation between cart and menu on mobile

### DIFF
--- a/site/components/common/UserNav/UserNav.tsx
+++ b/site/components/common/UserNav/UserNav.tsx
@@ -35,7 +35,7 @@ const UserNav: FC<Props> = ({ className }) => {
               variant="naked"
               onClick={() => {
                 setSidebarView('CART_VIEW')
-                toggleSidebar()
+                openSidebar()
               }}
               aria-label={`Cart items: ${itemsCount}`}
             >
@@ -76,7 +76,7 @@ const UserNav: FC<Props> = ({ className }) => {
             variant="naked"
             onClick={() => {
               setSidebarView('MOBILEMENU_VIEW')
-              toggleSidebar()
+              openSidebar()
             }}
             aria-label="Menu"
           >


### PR DESCRIPTION
On mobile when the Sidebar menu is open and you want to switch to cart, it would toggle the sidebar and close it instead of switching view.