### PR TITLE
docs(core): how to run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Demo live at: [demo.vercel.store](https://demo.vercel.store/)
 - Kibo Commerce Demo: https://kibocommerce.vercel.store/
 - Commerce.js Demo: https://commercejs.vercel.store/
 
+## Run minimal version locally 
+
+> deafult local provider `@vercel/commerce-local` has disabled all features (cart, auth) and use static files for the backend
+
+```bash
+yarn # run this comman in root folder of the mono repo
+yarn dev
+```
+
 ## Features
 
 - Performant by default
@@ -92,7 +101,7 @@ Follow our docs for [Adding a new Commerce Provider](packages/commerce/new-provi
 
 If you succeeded building a provider, submit a PR with a valid demo and we'll review it asap.
 
-## Contribute
+## Contribute / add new provider
 
 Our commitment to Open Source can be found [here](https://vercel.com/oss).
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ Demo live at: [demo.vercel.store](https://demo.vercel.store/)
 
 ## Run minimal version locally 
 
-> deafult local provider `@vercel/commerce-local` has disabled all features (cart, auth) and use static files for the backend
+> To run a minimal version of Next.js Commerce you can start with the default local provider `@vercel/commerce-local` that has disabled all features (cart, auth) and use static files for the backend
 
 ```bash
 yarn # run this comman in root folder of the mono repo
 yarn dev
 ```
+> If you encounter any problems while installing and running for the first time, please see the Troubleshoot section 
 
 ## Features
 
@@ -101,7 +102,7 @@ Follow our docs for [Adding a new Commerce Provider](packages/commerce/new-provi
 
 If you succeeded building a provider, submit a PR with a valid demo and we'll review it asap.
 
-## Contribute / add new provider
+## Contribute
 
 Our commitment to Open Source can be found [here](https://vercel.com/oss).
 


### PR DESCRIPTION
The purpose of this PR is to clarify how to run the project locally and highlight the fact that the default provider is just a stripped-down version of a real-life integration.