### PR TITLE
Import config with POSIX path

### DIFF
--- a/packages/commerce/src/config.cjs
+++ b/packages/commerce/src/config.cjs
@@ -16,7 +16,7 @@ function withCommerceConfig(nextConfig = {}) {
     )
   }
 
-  const commerceNextConfig = importCwd(path.join(provider, 'next.config'))
+  const commerceNextConfig = importCwd(path.posix.join(provider, 'next.config'))
   const config = merge(nextConfig, commerceNextConfig)
   const features = merge(
     config.commerce.features,


### PR DESCRIPTION
There seems to be an issue in Node.js when importing modules declared in the `exports` field of a `package.json` using Windows paths.

Importing a configuration with `@vercel/commerce-local/next-config` works, but `@vercel\commerce-local\next-config` (as returned by `path.join` on Windows systems) does not.

One possible workaround is to use `path.posix.join` to make sure that the imported path is specified as a POSIX path.

This PR should solve #681.
The `exports` problem might be related to https://github.com/nodejs/node/issues/30169.