### PR TITLE
Swell fixes

### DIFF
--- a/packages/swell/src/api/operations/get-product.ts
+++ b/packages/swell/src/api/operations/get-product.ts
@@ -20,10 +20,6 @@ export default function getProductOperation({
 
     const product = await config.fetch('products', 'get', [variables.slug])
 
-    if (product && product.variants) {
-      product.variants = product.variants?.results
-    }
-
     return {
       product: product ? normalizeProduct(product) : null,
     }

--- a/packages/swell/src/cart/use-add-item.tsx
+++ b/packages/swell/src/cart/use-add-item.tsx
@@ -3,7 +3,6 @@ import { CommerceError } from '@vercel/commerce/utils/errors'
 import useAddItem, { UseAddItem } from '@vercel/commerce/cart/use-add-item'
 import useCart from './use-cart'
 import { checkoutToCart } from './utils'
-import { getCheckoutId } from '../utils'
 import { useCallback } from 'react'
 import { AddItemHook } from '../types/cart'
 
@@ -26,10 +25,8 @@ export const handler: MutationHook<AddItemHook> = {
     const variables: {
       product_id: string | undefined
       variant_id?: string
-      checkoutId?: string
       quantity?: number
     } = {
-      checkoutId: getCheckoutId(),
       product_id: item.productId,
       quantity: item.quantity,
     }

--- a/packages/swell/src/types.ts
+++ b/packages/swell/src/types.ts
@@ -77,7 +77,7 @@ export interface SwellProduct {
   price: number
   images: any[]
   options: any[]
-  variants: any[]
+  variants: any
 }
 
 export type SwellCustomer = any

--- a/packages/swell/src/types/site.ts
+++ b/packages/swell/src/types/site.ts
@@ -1,1 +1,8 @@
 export * from '@vercel/commerce/types/site'
+import { Category } from "@vercel/commerce/types/site"
+
+export type SwellCategory = Category & {
+  children?: {
+    results: Category[]
+  }
+}

--- a/packages/swell/src/utils/get-sub-categories.ts
+++ b/packages/swell/src/utils/get-sub-categories.ts
@@ -1,0 +1,22 @@
+import { CommerceError } from "@vercel/commerce/utils/errors";
+import { SwellCategory } from "../types/site";
+
+export const getSubCategories = (
+  categoryId: string,
+  categories: SwellCategory[]
+) => {
+  const result: SwellCategory[] = []
+  const queue: string[] = [categoryId]
+  while (queue.length > 0) {
+    const curr = queue.shift()!
+    const category = categories.find((c) => c.id === curr)
+    if (!category) {
+      throw new CommerceError({
+        message: `Category ${category} not found.`
+      })
+    }
+    result.push(category)
+    queue.push(...(category.children?.results.map((c) => c.id) ?? []))
+  }
+  return result
+}

--- a/packages/swell/src/utils/normalize.ts
+++ b/packages/swell/src/utils/normalize.ts
@@ -127,7 +127,7 @@ export function normalizeProduct(swellProduct: SwellProduct): Product {
     ? options.map((o) => normalizeProductOption(o))
     : []
   const productVariants = variants
-    ? normalizeProductVariants(variants, options)
+    ? normalizeProductVariants(variants.results, options)
     : []
 
   const productImages = normalizeProductImages(images)


### PR DESCRIPTION
- Fixed "use-add-item" hook: removed the checkoutId from the request variables. We can't pass the checkoutId to swell because they already use the current session to determine the checkoutId (see use-update-item and use-remove-item).
```
 {
    "code": "permission_error",
    "message": "You are not allowed to update `items.checkoutId`",
    "param": "items.checkoutId"
  }
```

- Fixed search sort: remove the underscore from the sort values ("price_asc", "price_desc"). Swell expect the format `${field} ${direction}`.

- Fixed "use-login" hook: 
```
Unhandled Runtime Error. TypeError: Cannot read properties of undefined (reading '0').
````
Receiving this error when an account doesn't exist.

- Moved the product variants normalization to normalizeProduct: For my use case, I had to expand the "use-search" hook to add product variants too. The normalize function didn't work because it was expecting the variants to be normalized before (see the "get-product operations"). It makes more sense to normalize everything inside the normalize function.

- Add includeSubCategories to "use-search" hook: In swell, you can define a category tree structure. For example
```
Category A
	Category B
		Product B1
		Product B2
Category C
	Product C1
	Category D
		Product D1
		Product D2
```
In the search page, if you filter by Category D, you would get product D1 and D2. But, if you filter C, you would only get product C1, or even worse, if you filter by Category A, the response is "No product found!"
	