### PR TITLE
Fixes minor issue if categories are empty in commercejs

### DIFF
--- a/packages/commercejs/src/api/operations/get-site-info.ts
+++ b/packages/commercejs/src/api/operations/get-site-info.ts
@@ -24,6 +24,13 @@ export default function getSiteInfoOperation({
     const { sdkFetch } = commerce.getConfig(config)
     const { data: categories } = await sdkFetch('categories', 'list')
 
+    if (!categories) {
+      return {
+        categories: [],
+        brands: [],
+      }
+    }
+
     const formattedCategories = categories.map(normalizeCategory)
 
     return {

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -23,8 +23,8 @@
       "@components/*": ["components/*"],
       "@commerce": ["../packages/commerce/src"],
       "@commerce/*": ["../packages/commerce/src/*"],
-      "@framework": ["../packages/local/src"],
-      "@framework/*": ["../packages/local/src/*"]
+      "@framework": ["../packages/commercejs/src"],
+      "@framework/*": ["../packages/commercejs/src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.d.ts", "**/*.ts", "**/*.tsx", "**/*.js"],


### PR DESCRIPTION
Categories are optional in commercejs. If the merchant does not setup categories, `categories` will not be defined, so `categories.map()` causes problems.