### PR TITLE
MERC-8927 Related products query

### DIFF
--- a/packages/bigcommerce/src/api/operations/get-product.ts
+++ b/packages/bigcommerce/src/api/operations/get-product.ts
@@ -21,6 +21,13 @@ export const getProductQuery = /* GraphQL */ `
           __typename
           ... on Product {
             ...productInfo
+            relatedProducts(first: 4) {
+              edges {
+                node {
+                  ...productInfo
+                }
+              }
+            }
             variants(first: 250) {
               edges {
                 node {

--- a/packages/commerce/src/types/product.ts
+++ b/packages/commerce/src/types/product.ts
@@ -43,6 +43,7 @@ export type Product = {
   variants: ProductVariant[]
   price: ProductPrice
   options: ProductOption[]
+  relatedProducts?: Product[]
   vendor?: string
 }
 

--- a/packages/commercejs/src/utils/normalize-product.ts
+++ b/packages/commercejs/src/utils/normalize-product.ts
@@ -54,7 +54,7 @@ export function normalizeProduct(
   commercejsProduct: CommercejsProduct,
   commercejsProductVariants: Array<CommercejsVariant> = []
 ): Product {
-  const { id, name, description, permalink, assets, price, variant_groups } =
+  const { id, name, description, permalink, assets, price, related_products, variant_groups } =
     commercejsProduct
   return {
     id,
@@ -71,6 +71,7 @@ export function normalizeProduct(
       value: price.raw,
       currencyCode: 'USD',
     },
+    relatedProducts: related_products,
     variants: normalizeVariants(commercejsProductVariants, variant_groups),
     options: getOptionsFromVariantGroups(variant_groups),
   }

--- a/site/pages/product/[slug].tsx
+++ b/site/pages/product/[slug].tsx
@@ -31,7 +31,7 @@ export async function getStaticProps({
   const { pages } = await pagesPromise
   const { categories } = await siteInfoPromise
   const { product } = await productPromise
-  const { products: relatedProducts } = await allProductsPromise
+  const { products } = await allProductsPromise
 
   if (!product) {
     throw new Error(`Product with slug '${params!.slug}' not found`)
@@ -41,7 +41,7 @@ export async function getStaticProps({
     props: {
       pages,
       product,
-      relatedProducts,
+      products,
       categories,
     },
     revalidate: 200,
@@ -67,9 +67,10 @@ export async function getStaticPaths({ locales }: GetStaticPathsContext) {
 
 export default function Slug({
   product,
-  relatedProducts,
+  products,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const router = useRouter()
+  let relatedProducts = product.relatedProducts ? product.relatedProducts : products;
 
   return router.isFallback ? (
     <h1>Loading...</h1>


### PR DESCRIPTION
Fix related products to respect custom related products from Control Panel.

Currently the related products field is not being respected from the Control Panel. This change is to pull the `related products` data from the individual product and to display the correct related products on the PDP (Product Details Page)

**Customized Related Products from CP**
<img width="1680" alt="Screen Shot 2022-08-23 at 1 06 19 PM" src="https://user-images.githubusercontent.com/33278039/186221237-63010b4e-a043-4d64-99b0-c9f5543154a6.png">


**Updated Related Products on PDP**
<img width="1680" alt="Screen Shot 2022-08-23 at 1 09 08 PM" src="https://user-images.githubusercontent.com/33278039/186221484-aa142fdf-c198-438f-8baa-a4701a51b078.png">

