### PR TITLE
Update Shopify URL actual release

### DIFF
--- a/packages/shopify/src/const.ts
+++ b/packages/shopify/src/const.ts
@@ -8,6 +8,6 @@ export const STORE_DOMAIN = process.env.NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN
 
 export const SHOPIFY_COOKIE_EXPIRE = 30
 
-export const API_URL = `https://${STORE_DOMAIN}/api/2021-07/graphql.json`
+export const API_URL = `https://${STORE_DOMAIN}/api/2022-07/graphql.json`
 
 export const API_TOKEN = process.env.NEXT_PUBLIC_SHOPIFY_STOREFRONT_ACCESS_TOKEN


### PR DESCRIPTION
The storefront api has changes about metafields that now work differently.

The current shopify storefront api documentation handles the examples with the new version.