### PR TITLE
Fix Shopify search

### DIFF
--- a/packages/shopify/src/utils/get-search-variables.ts
+++ b/packages/shopify/src/utils/get-search-variables.ts
@@ -11,7 +11,7 @@ export const getSearchVariables = ({
   let query = ''
 
   if (search) {
-    query += `product_type:${search} OR title:${search} OR tag:${search} `
+    query += `product_type:"${search}" OR title:"${search}" OR tag:"${search}" `
   }
 
   if (brandId) {


### PR DESCRIPTION
Fixes search when there is space in the search term #845 

Before: https://shopify.vercel.store/search?q=special+edition
After: https://commerce-shopify-a9br2mhp7-vercel-solutions-vtest314.vercel.app/search?q=special+edition