### PR TITLE
Remove native arrow buttons from input number (Firefox)

### DIFF
--- a/site/components/ui/Quantity/Quantity.module.css
+++ b/site/components/ui/Quantity/Quantity.module.css
@@ -23,5 +23,5 @@
 }
 
 .input {
-  @apply bg-transparent px-4 w-full h-full focus:outline-none select-none pointer-events-auto;
+  @apply [appearance:textfield] bg-transparent px-4 w-full h-full focus:outline-none select-none pointer-events-auto;
 }


### PR DESCRIPTION
**Problem**: Native arrow buttons appear on Firefox (only)

### How to reproduce:

1. Open [https://demo.vercel.store](https://demo.vercel.store) with Firefox 
2. Add a product to cart
3. Open your cart

### Where is The problem:

- Side view cart [https://demo.vercel.store](https://demo.vercel.store)
- Cart page: [https://demo.vercel.store/cart](https://demo.vercel.store/cart)
---
What we want:
![UI_bug](https://user-images.githubusercontent.com/92606530/198992264-2423ce32-bf2c-4d9d-bba1-d8a6e164415c.png)

What we actually have on Firefox:
![UI_fix](https://user-images.githubusercontent.com/92606530/198992251-0b17198f-641d-4b45-bf3b-6c1360329540.png)


It is resolved by adding ``[appearance:textfield]`` in the input class from the ``site/components/ui/Quantity/Quantity.module.css`` file