### PR TITLE
Fix Commerce.js product normalizer

### DIFF
--- a/packages/commercejs/src/api/operations/get-site-info.ts
+++ b/packages/commercejs/src/api/operations/get-site-info.ts
@@ -27,7 +27,7 @@ export default function getSiteInfoOperation({
     const { sdkFetch } = commerce.getConfig(config)
     const { data: categories } = await sdkFetch('categories', 'list')
 
-    const formattedCategories = categories.map(normalizeCategory)
+    const formattedCategories = categories?.map(normalizeCategory) ?? []
 
     return {
       categories: formattedCategories,

--- a/packages/commercejs/src/cart/use-add-item.tsx
+++ b/packages/commercejs/src/cart/use-add-item.tsx
@@ -22,17 +22,17 @@ export const handler: MutationHook<AddItemHook> = {
       variables.push(item.variantId)
     }
 
-    const { cart } = await fetch<{ cart: CommercejsCart }>({
+    const cart = await fetch<CommercejsCart>({
       query: options.query,
       method: options.method,
       variables,
     })
+
     return normalizeCart(cart)
   },
   useHook: ({ fetch }) =>
     function useHook() {
       const { mutate } = useCart()
-
       return useCallback(
         async function addItem(input) {
           const cart = await fetch({ input })

--- a/packages/commercejs/src/cart/use-remove-item.tsx
+++ b/packages/commercejs/src/cart/use-remove-item.tsx
@@ -16,7 +16,7 @@ export const handler: MutationHook<RemoveItemHook> = {
     method: 'remove',
   },
   async fetcher({ input, options, fetch }) {
-    const { cart } = await fetch<{ cart: CommercejsCart }>({
+    const cart = await fetch<CommercejsCart>({
       query: options.query,
       method: options.method,
       variables: input.itemId,

--- a/packages/commercejs/src/cart/use-update-item.tsx
+++ b/packages/commercejs/src/cart/use-update-item.tsx
@@ -30,7 +30,7 @@ export const handler = {
   },
   async fetcher({ input, options, fetch }: HookFetcherContext<UpdateItemHook>) {
     const variables = [input.itemId, { quantity: input.item.quantity }]
-    const { cart } = await fetch<{ cart: CommercejsCart }>({
+    const cart = await fetch<CommercejsCart>({
       query: options.query,
       method: options.method,
       variables,
@@ -57,7 +57,7 @@ export const handler = {
           const variantId = input.productId ?? item?.variantId
           const quantity = input?.quantity ?? item?.quantity
 
-          if (!itemId || !productId || !variantId) {
+          if (!itemId || !productId) {
             throw new ValidationError({
               message: 'Invalid input for updating cart item',
             })
@@ -69,7 +69,7 @@ export const handler = {
               item: {
                 quantity,
                 productId,
-                variantId,
+                variantId: variantId ?? '',
               },
             },
           })

--- a/packages/commercejs/src/utils/normalize-cart.ts
+++ b/packages/commercejs/src/utils/normalize-cart.ts
@@ -44,14 +44,16 @@ const normalizeLineItem = (
   }
 }
 
-export const normalizeCart = (commercejsCart: CommercejsCart): Cart => {
+export const normalizeCart = (
+  commercejsCart: CommercejsCart | { cart: CommercejsCart }
+): Cart => {
   const {
     id,
     created,
     subtotal: { raw: rawPrice },
     currency,
     line_items,
-  } = commercejsCart
+  } = 'cart' in commercejsCart ? commercejsCart.cart : commercejsCart
 
   return {
     id,

--- a/packages/commercejs/src/utils/normalize-product.ts
+++ b/packages/commercejs/src/utils/normalize-product.ts
@@ -54,6 +54,7 @@ export function normalizeProduct(
 ): Product {
   const { id, name, description, permalink, assets, price, variant_groups } =
     commercejsProduct
+
   return {
     id,
     name,
@@ -70,7 +71,10 @@ export function normalizeProduct(
       value: price.raw,
       currencyCode: 'USD',
     },
-    variants: normalizeVariants(commercejsProductVariants, variant_groups),
-    options: getOptionsFromVariantGroups(variant_groups),
+    variants: normalizeVariants(
+      commercejsProductVariants,
+      variant_groups || []
+    ),
+    options: variant_groups ? getOptionsFromVariantGroups(variant_groups) : [],
   }
 }

--- a/packages/commercejs/src/utils/normalize-product.ts
+++ b/packages/commercejs/src/utils/normalize-product.ts
@@ -61,10 +61,11 @@ export function normalizeProduct(
     descriptionHtml: description,
     slug: permalink,
     path: `/${permalink}`,
-    images: assets.map(({ url, description, filename }) => ({
-      url,
-      alt: description || filename,
-    })),
+    images:
+      assets?.map(({ url, description, filename }) => ({
+        url,
+        alt: description || filename,
+      })) || [],
     price: {
       value: price.raw,
       currencyCode: 'USD',


### PR DESCRIPTION
Fixes #874, `assets` is optional now and throws an error when a product has no images.