### PR TITLE
Fix turbo issues : `Declaring an environment variable in "dependsOn" is deprecated`

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -8,11 +8,13 @@
     },
     "next-commerce#build": {
       "dependsOn": [
-        "^build",
-        "$COMMERCE_PROVIDER",
-        "$BIGCOMMERCE_STOREFRONT_API_URL",
-        "$NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN",
-        "$NEXT_PUBLIC_SWELL_STORE_ID"
+        "^build"
+      ],
+      "env": [
+        "COMMERCE_PROVIDER",
+        "BIGCOMMERCE_STOREFRONT_API_URL",
+        "NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN",
+        "NEXT_PUBLIC_SWELL_STORE_ID"
       ],
       "outputs": [".next/**"]
     },


### PR DESCRIPTION
Our CI/CD system is throwing these errors:

```log
2022/12/07 16:10:43 [DEPRECATED] Declaring an environment variable in "dependsOn" is deprecated, found $COMMERCE_PROVIDER. Use the "env" key or use `npx @turbo/codemod migrate-env-var-dependencies`.
2022/12/07 16:10:43 [DEPRECATED] Declaring an environment variable in "dependsOn" is deprecated, found $BIGCOMMERCE_STOREFRONT_API_URL. Use the "env" key or use `npx @turbo/codemod migrate-env-var-dependencies`.
2022/12/07 16:10:43 [DEPRECATED] Declaring an environment variable in "dependsOn" is deprecated, found $NEXT_PUBLIC_SHOPIFY_STORE_DOMAIN. Use the "env" key or use `npx @turbo/codemod migrate-env-var-dependencies`.
2022/12/07 16:10:43 [DEPRECATED] Declaring an environment variable in "dependsOn" is deprecated, found $NEXT_PUBLIC_SWELL_STORE_ID. Use the "env" key or use `npx @turbo/codemod migrate-env-var-dependencies`.
```

Looking at the [Turbo Documentation](https://turbo.build/repo/docs/reference/configuration#dependson) it shows this warning:

> ℹ Using `$` to declare environment variables in the `dependsOn` config is deprecated. Use the `env` key instead.

This PR is attempting to address this change in `turbo` by updating `turbo.json` in this repo.