### PR TITLE
Don't fail when collections are not found

### DIFF
--- a/components/layout/product-grid-items.tsx
+++ b/components/layout/product-grid-items.tsx
@@ -17,7 +17,7 @@ export default function ProductGridItems({ products }: { products: Product[] }) 
                 amount: product.priceRange.maxVariantPrice.amount,
                 currencyCode: product.priceRange.maxVariantPrice.currencyCode
               }}
-              src={product.featuredImage.url}
+              src={product.featuredImage?.url}
               width={600}
               height={600}
             />

--- a/components/product/gallery.tsx
+++ b/components/product/gallery.tsx
@@ -82,7 +82,7 @@ export function Gallery({
                 onClick={() => setCurrentImage(index)}
               >
                 <GridTileImage
-                  alt={image.altText}
+                  alt={image?.altText}
                   src={image.src}
                   width={600}
                   height={600}

--- a/lib/shopify/index.ts
+++ b/lib/shopify/index.ts
@@ -265,6 +265,11 @@ export async function getCollectionProducts(handle: string): Promise<Product[]> 
     }
   });
 
+  if (!res.body.data.collection) {
+    console.log('No collection found for handle', handle);
+    return [];
+  }
+
   return reshapeProducts(removeEdgesAndNodes(res.body.data.collection.products));
 }
 


### PR DESCRIPTION
I had the issue when trying Vercel commerce with my old development shopify store (https://aby-tester.myshopify.com/)

It crashed due to not properly set collections. I think it should be still able to render the store.

- Fixes #983 and logs what collections are not set up properly. 
- Also fixes a crash where no images are set for a product
