### PR TITLE
feat(typesafety):return-types|readonly

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,8 +1,11 @@
 import { ReadonlyURLSearchParams } from 'next/navigation';
 
-export const createUrl = (pathname: string, params: URLSearchParams | ReadonlyURLSearchParams) => {
+export const createUrl = (
+  pathname: string,
+  params: Readonly<URLSearchParams> | ReadonlyURLSearchParams
+): string => {
   const paramsString = params.toString();
-  const queryString = `${paramsString.length ? '?' : ''}${paramsString}`;
+  const queryString = paramsString ? `?${paramsString}` : '';
 
   return `${pathname}${queryString}`;
 };


### PR DESCRIPTION
 Utility function | Additional Typesafety
 -  Explicit return type ( string ) -> The return type should be a string since the function returns a URL.
 -  Implicit readonly on types.
 - Template literals with conditional operator instead of string concatenation
