### PR TITLE
Fixes relevance removing search query

### DIFF
--- a/components/layout/search/filter/item.tsx
+++ b/components/layout/search/filter/item.tsx
@@ -13,6 +13,7 @@ function PathFilterItem({ item }: { item: PathFilterItem }) {
   const searchParams = useSearchParams();
   const [active, setActive] = useState(pathname === item.path);
   const newParams = new URLSearchParams(searchParams.toString());
+  const DynamicTag = active ? 'p' : Link;
 
   newParams.delete('q');
 
@@ -22,7 +23,7 @@ function PathFilterItem({ item }: { item: PathFilterItem }) {
 
   return (
     <li className="mt-2 flex text-black dark:text-white" key={item.title}>
-      <Link
+      <DynamicTag
         href={createUrl(item.path, newParams)}
         className={clsx(
           'w-full text-sm underline-offset-4 hover:underline dark:hover:text-gray-100',
@@ -32,7 +33,7 @@ function PathFilterItem({ item }: { item: PathFilterItem }) {
         )}
       >
         {item.title}
-      </Link>
+      </DynamicTag>
     </li>
   );
 }
@@ -42,33 +43,30 @@ function SortFilterItem({ item }: { item: SortFilterItem }) {
   const searchParams = useSearchParams();
   const [active, setActive] = useState(searchParams.get('sort') === item.slug);
   const q = searchParams.get('q');
+  const href = createUrl(
+    pathname,
+    new URLSearchParams({
+      ...(q && { q }),
+      ...(item.slug && item.slug.length && { sort: item.slug })
+    })
+  );
+  const DynamicTag = active ? 'p' : Link;
 
   useEffect(() => {
     setActive(searchParams.get('sort') === item.slug);
   }, [searchParams, item.slug]);
 
-  const href =
-    item.slug && item.slug.length
-      ? createUrl(
-          pathname,
-          new URLSearchParams({
-            ...(q && { q }),
-            sort: item.slug
-          })
-        )
-      : pathname;
-
   return (
     <li className="mt-2 flex text-sm text-black dark:text-white" key={item.title}>
-      <Link
-        prefetch={false}
+      <DynamicTag
+        prefetch={!active ? false : undefined}
         href={href}
         className={clsx('w-full', {
           'underline underline-offset-4': active
         })}
       >
         {item.title}
-      </Link>
+      </DynamicTag>
     </li>
   );
 }


### PR DESCRIPTION
Also dynamically rendered the active element as a `p` tag instead of a link. No need to use a link if we're already on that element. 

### Before

https://github.com/vercel/commerce/assets/446260/98fc4d08-ff91-4789-94e8-78d5b7c66829

### After

https://github.com/vercel/commerce/assets/446260/2da6c973-6e87-48b3-9050-5c1f3c4c6e43