### PR TITLE
Fixes focus styles when clicking

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,5 +11,5 @@
 a,
 input,
 button {
-  @apply focus:outline-none focus:ring-2 focus:ring-neutral-400 focus:ring-offset-2 focus:ring-offset-neutral-50 dark:focus:ring-neutral-600 dark:focus:ring-offset-neutral-900;
+  @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-50 dark:focus-visible:ring-neutral-600 dark:focus-visible:ring-offset-neutral-900;
 }


### PR DESCRIPTION
Using just `focus` will also pick up clicks in certain browser, like Chrome. The element becomes "in focus" when it's clicked. We can use `focus-visible` instead, which "styles an element when it has been focused using the keyboard". Perf. 👌 

### Before 

https://github.com/vercel/commerce/assets/446260/ed9ca1f7-c0ad-4271-b5dc-a2e5c1253830

### After

https://github.com/vercel/commerce/assets/446260/a8107ac2-cad6-46cf-9b0e-1c163a635562