### PR TITLE
Fix variant disabled styles

### DIFF
--- a/components/product/variant-selector.tsx
+++ b/components/product/variant-selector.tsx
@@ -119,7 +119,7 @@ export function VariantSelector({
                   'cursor-default ring-2 ring-blue-600': isActive,
                   'ring-1 ring-transparent transition duration-300 ease-in-out hover:scale-110 hover:ring-blue-600 ':
                     !isActive && isAvailableForSale,
-                  'relative z-10 cursor-not-allowed overflow-hidden bg-neutral-100 ring-1 ring-neutral-300 before:absolute before:inset-x-0 before:-z-10 before:h-px before:-rotate-45 before:bg-neutral-300 before:transition-transform dark:bg-neutral-900 dark:ring-neutral-700 before:dark:bg-neutral-700':
+                  'relative z-10 cursor-not-allowed overflow-hidden bg-neutral-100 text-neutral-400 ring-1 ring-neutral-300 before:absolute before:inset-x-0 before:-z-10 before:h-px before:-rotate-45 before:bg-neutral-300 before:transition-transform dark:bg-neutral-900 dark:text-neutral-600 dark:ring-neutral-700 before:dark:bg-neutral-700':
                     !isAvailableForSale
                 }
               )}


### PR DESCRIPTION
The redesign made it more difficult to see if a variant is disabled. Tweaks the text styles a bit to make it more noticeable.

### Before

![CleanShot 2023-07-17 at 19 45 57@2x](https://github.com/vercel/commerce/assets/446260/e60ef20c-6839-4ba0-aa91-b8beb6dca390)

### After

![CleanShot 2023-07-17 at 19 44 53@2x](https://github.com/vercel/commerce/assets/446260/2ef21fa7-be9b-4e65-ac57-9dd5edd90847)