### PR TITLE
Fixes cart icon inconsistent size

### DIFF
--- a/components/layout/navbar/index.tsx
+++ b/components/layout/navbar/index.tsx
@@ -48,7 +48,7 @@ export default async function Navbar() {
           <Search />
         </div>
         <div className="flex justify-end md:w-1/3">
-          <Suspense fallback={<OpenCart className="h-6" />}>
+          <Suspense fallback={<OpenCart />}>
             <Cart />
           </Suspense>
         </div>


### PR DESCRIPTION
Should fix this cart icon size flash.

![CleanShot 2023-07-25 at 11 56 35](https://github.com/vercel/commerce/assets/446260/4f606bdf-a847-483a-913c-645e585e61c6)
