### PR TITLE
Set color-scheme in dark mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@media (prefers-color-scheme: dark) {
+  html {
+    color-scheme: dark;
+  }
+}
+
 @supports (font: -apple-system-body) and (-webkit-appearance: none) {
   img[loading='lazy'] {
     clip-path: inset(0.6px);


### PR DESCRIPTION
This fixes an issue with the color of scrollbars in dark mode.

### Before:
<img width="1727" alt="image" src="https://github.com/vercel/commerce/assets/2020473/13675829-871d-481e-ae49-beed9e0c25d3">

### After:
<img width="868" alt="image" src="https://github.com/vercel/commerce/assets/2020473/4d9a6bbe-3c99-4517-9df2-d80f2b1eede4">
