### PR TITLE
Fix hydration error

### DIFF
--- a/components/product/variant-selector.tsx
+++ b/components/product/variant-selector.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { ProductOption, ProductVariant } from 'lib/shopify/types';
 import { createUrl } from 'lib/utils';
 import Link from 'next/link';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { redirect, usePathname, useSearchParams } from 'next/navigation';
 
 type ParamsMap = {
   [key: string]: string; // ie. { color: 'Red', size: 'Large', ... }
@@ -26,7 +26,6 @@ export function VariantSelector({
 }) {
   const pathname = usePathname();
   const currentParams = useSearchParams();
-  const router = useRouter();
   const hasNoOptionsOrJustOneOption =
     !options.length || (options.length === 1 && options[0]?.values.length === 1);
 
@@ -80,7 +79,7 @@ export function VariantSelector({
   const selectedVariantUrl = createUrl(pathname, selectedVariantParams);
 
   if (currentUrl !== selectedVariantUrl) {
-    router.replace(selectedVariantUrl);
+    redirect(selectedVariantUrl);
   }
 
   return options.map((option) => (


### PR DESCRIPTION
Calling router.replace / router.push (or any other router method) is not supported during render. You have to do that kind of call in `useEffect` or a handler for an interaction like onClick / onSubmit. `redirect()` and `notFound()` are designed so that you can call them during rendering.
