### PR TITLE
Adds anchor for v1 note

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Next.js 13 and App Router-ready ecommerce template featuring:
 
 <h3 id="v1-note"></h3>
 
-> Note: Looking for Next.js Commerce v1? View the [code](https://github.com/vercel/commerce/tree/v1), [demo](https://commerce-v1.vercel.store), and [release notes](https://github.com/vercel/commerce/releases/tag/v1)
+> Note: Looking for Next.js Commerce v1? View the [code](https://github.com/vercel/commerce/tree/v1), [demo](https://commerce-v1.vercel.store), and [release notes](https://github.com/vercel/commerce/releases/tag/v1).
 
 ## Providers
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A Next.js 13 and App Router-ready ecommerce template featuring:
 - Checkout and payments with Shopify
 - Automatic light/dark mode based on system settings
 
+<h3 id="v1-note"></h3>
+
 > Note: Looking for Next.js Commerce v1? View the [code](https://github.com/vercel/commerce/tree/v1), [demo](https://commerce-v1.vercel.store), and [release notes](https://github.com/vercel/commerce/releases/tag/v1)
 
 ## Providers


### PR DESCRIPTION
So it can be linked to directly. For example: https://github.com/vercel/commerce/blob/8e0198c67d06d95b2cbd6b6b9fd79c77cc94e480/README.md#v1-note