### PR TITLE
Rename `hide` to `indexable`

### DIFF
--- a/app/product/[handle]/page.tsx
+++ b/app/product/[handle]/page.tsx
@@ -23,17 +23,17 @@ export async function generateMetadata({
   if (!product) return notFound();
 
   const { url, width, height, altText: alt } = product.featuredImage || {};
-  const hide = !product.tags.includes(HIDDEN_PRODUCT_TAG);
+  const indexable = !product.tags.includes(HIDDEN_PRODUCT_TAG);
 
   return {
     title: product.seo.title || product.title,
     description: product.seo.description || product.description,
     robots: {
-      index: hide,
-      follow: hide,
+      index: indexable,
+      follow: indexable,
       googleBot: {
-        index: hide,
-        follow: hide
+        index: indexable,
+        follow: indexable
       }
     },
     openGraph: url


### PR DESCRIPTION
Rename variable name `hide` to `indexable` because the variable name was not representing the actual meaning.