### PR TITLE
Adjusts product card titles for better Lighthouse score

### DIFF
--- a/components/label.tsx
+++ b/components/label.tsx
@@ -19,7 +19,7 @@ const Label = ({
       })}
     >
       <div className="flex w-full items-center rounded-full border bg-white/70 p-1 text-xs font-semibold text-black backdrop-blur-md dark:border-neutral-800 dark:bg-black/70 dark:text-white">
-        <h3 className="mr-4 flex-grow truncate pl-2 leading-none tracking-tight">{title}</h3>
+        <h3 className="mr-4 line-clamp-2 flex-grow pl-2 leading-none tracking-tight">{title}</h3>
         <Price
           className="flex-none rounded-full bg-blue-600 p-2 text-white"
           amount={amount}

--- a/components/label.tsx
+++ b/components/label.tsx
@@ -18,8 +18,8 @@ const Label = ({
         'lg:px-20 lg:pb-[35%]': position === 'center'
       })}
     >
-      <div className="flex items-center rounded-full border bg-white/70 p-1 text-[10px] font-semibold text-black backdrop-blur-md @[275px]/label:text-xs dark:border-neutral-800 dark:bg-black/70 dark:text-white">
-        <h3 className="mr-4 inline pl-2 leading-none tracking-tight">{title}</h3>
+      <div className="flex w-full items-center rounded-full border bg-white/70 p-1 text-xs font-semibold text-black backdrop-blur-md dark:border-neutral-800 dark:bg-black/70 dark:text-white">
+        <h3 className="mr-4 flex-grow truncate pl-2 leading-none tracking-tight">{title}</h3>
         <Price
           className="flex-none rounded-full bg-blue-600 p-2 text-white"
           amount={amount}


### PR DESCRIPTION
Attempt to fix this Lighthouse issue. 

![CleanShot 2023-08-04 at 16 27 06@2x](https://github.com/vercel/commerce/assets/446260/345d2ab8-b95f-442a-b8ff-4b4bf3db64a8)

Replaces small font with [line-camp](https://tailwindcss.com/docs/line-clamp).

![CleanShot 2023-08-04 at 16 40 40@2x](https://github.com/vercel/commerce/assets/446260/b8c73def-5a36-436e-8f45-868f0ec8a69e)