### PR TITLE
Fixes long product card titles

### DIFF
--- a/components/label.tsx
+++ b/components/label.tsx
@@ -18,7 +18,7 @@ const Label = ({
         'lg:px-20 lg:pb-[35%]': position === 'center'
       })}
     >
-      <div className="flex w-full items-center rounded-full border bg-white/70 p-1 text-xs font-semibold text-black backdrop-blur-md dark:border-neutral-800 dark:bg-black/70 dark:text-white">
+      <div className="flex items-center rounded-full border bg-white/70 p-1 text-xs font-semibold text-black backdrop-blur-md dark:border-neutral-800 dark:bg-black/70 dark:text-white">
         <h3 className="mr-4 line-clamp-2 flex-grow pl-2 leading-none tracking-tight">{title}</h3>
         <Price
           className="flex-none rounded-full bg-blue-600 p-2 text-white"


### PR DESCRIPTION
Accidentally borked this in #1147. 

![CleanShot 2023-08-04 at 16 57 32@2x](https://github.com/vercel/commerce/assets/446260/4a906285-98bb-4947-9b1d-48af8470da9b)
