### PR TITLE
Fixes product detail spacing

### DIFF
--- a/app/product/[handle]/page.tsx
+++ b/app/product/[handle]/page.tsx
@@ -82,7 +82,7 @@ export default async function ProductPage({ params }: { params: { handle: string
         }}
       />
       <div className="mx-auto max-w-screen-2xl px-4">
-        <div className="flex flex-col rounded-lg border border-neutral-200 bg-white p-8 dark:border-neutral-800 dark:bg-black md:p-12 lg:flex-row">
+        <div className="flex flex-col rounded-lg border border-neutral-200 bg-white p-8 dark:border-neutral-800 dark:bg-black md:p-12 lg:flex-row lg:gap-8">
           <div className="h-full w-full basis-full lg:basis-4/6">
             <Gallery
               images={product.images.map((image: Image) => ({


### PR DESCRIPTION
Only noticeable with landscape images. Since there aren't many, it went unnoticed. 

### Before 

![CleanShot 2023-08-08 at 09 56 21@2x](https://github.com/vercel/commerce/assets/446260/90763302-c9f6-49ac-a6b0-c7fda994b0aa)

### After

![CleanShot 2023-08-08 at 09 55 51@2x](https://github.com/vercel/commerce/assets/446260/d98c04ab-9c80-4bb0-bc16-7a604b9d37b4)
