### PR TITLE
Changes product detail gallery thumbnails to always be square

### DIFF
--- a/components/product/gallery.tsx
+++ b/components/product/gallery.tsx
@@ -74,7 +74,7 @@ export function Gallery({ images }: { images: { src: string; altText: string }[]
             imageSearchParams.set('image', index.toString());
 
             return (
-              <li key={image.src} className="h-auto w-20">
+              <li key={image.src} className="h-20 w-20">
                 <Link
                   aria-label="Enlarge product image"
                   href={createUrl(pathname, imageSearchParams)}


### PR DESCRIPTION
### Before

![CleanShot 2023-08-08 at 10 11 26@2x](https://github.com/vercel/commerce/assets/446260/c6eca641-c44c-4a47-a422-775e7cd7a4a7)

### After
![CleanShot 2023-08-08 at 10 11 13@2x](https://github.com/vercel/commerce/assets/446260/216577d4-2607-4dc7-b440-c566bde18221)
