### PR TITLE
Adds redirect for `/password`

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,5 +16,14 @@ module.exports = {
         pathname: '/s/files/**'
       }
     ]
+  },
+  async redirects() {
+    return [
+      {
+        source: '/password',
+        destination: '/',
+        permanent: true
+      }
+    ];
   }
 };


### PR DESCRIPTION
The headless Shopify theme takes care of most redirects with the exception of a password protected site, which can inadvertently land people back on the Next.js theme's `/password` route.

This PR adds a redirect to handle this.

Fixes #1155