### PR TITLE
Fixes accessibility issue with home page link in header

### DIFF
--- a/components/layout/navbar/index.tsx
+++ b/components/layout/navbar/index.tsx
@@ -19,11 +19,7 @@ export default async function Navbar() {
       </div>
       <div className="flex w-full items-center">
         <div className="flex w-full md:w-1/3">
-          <Link
-            href="/"
-            aria-label="Go back home"
-            className="mr-2 flex w-full items-center justify-center md:w-auto lg:mr-6"
-          >
+          <Link href="/" className="mr-2 flex w-full items-center justify-center md:w-auto lg:mr-6">
             <LogoSquare />
             <div className="ml-2 flex-none text-sm font-medium uppercase md:hidden lg:block">
               {SITE_NAME}


### PR DESCRIPTION
Attempt to fix this Lighthouse issue. Shouldn't need a label. Text can be inferred from the link text.

![CleanShot 2023-08-11 at 08 51 21@2x](https://github.com/vercel/commerce/assets/446260/2ab690a2-0673-4c24-aef9-6daeee2f9909)

![CleanShot 2023-08-11 at 08 47 59@2x](https://github.com/vercel/commerce/assets/446260/ce634984-9e0a-4367-98fa-90594c36d750)
