### PR TITLE
Adds environment variable validation

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,4 +1,5 @@
 import { getCollections, getPages, getProducts } from 'lib/shopify';
+import { validateEnvironmentVariables } from 'lib/utils';
 import { MetadataRoute } from 'next';
 
 type Route = {
@@ -11,6 +12,8 @@ const baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL
   : 'http://localhost:3000';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  validateEnvironmentVariables()
+
   const routesMap = [''].map((route) => ({
     url: `${baseUrl}${route}`,
     lastModified: new Date().toISOString()

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -12,7 +12,7 @@ const baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL
   : 'http://localhost:3000';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  validateEnvironmentVariables()
+  validateEnvironmentVariables();
 
   const routesMap = [''].map((route) => ({
     url: `${baseUrl}${route}`,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -21,10 +21,19 @@ export const validateEnvironmentVariables = () => {
   });
 
   if (missingEnvironmentVariables.length) {
-    throw new Error(`The following environment variables are missing. Your site will not work without them.\n\n${missingEnvironmentVariables.join('\n')}\n`);
+    throw new Error(
+      `The following environment variables are missing. Your site will not work without them.\n\n${missingEnvironmentVariables.join(
+        '\n'
+      )}\n`
+    );
   }
 
-  if (process.env.SHOPIFY_STORE_DOMAIN?.includes('[') || process.env.SHOPIFY_STORE_DOMAIN?.includes(']')) {
-    throw new Error('Your `SHOPIFY_STORE_DOMAIN` environment variable includes brackets (ie. `[` and / or `]`). Your site will not work with them there. Please remove them.');
+  if (
+    process.env.SHOPIFY_STORE_DOMAIN?.includes('[') ||
+    process.env.SHOPIFY_STORE_DOMAIN?.includes(']')
+  ) {
+    throw new Error(
+      'Your `SHOPIFY_STORE_DOMAIN` environment variable includes brackets (ie. `[` and / or `]`). Your site will not work with them there. Please remove them.'
+    );
   }
-}
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -22,7 +22,7 @@ export const validateEnvironmentVariables = () => {
 
   if (missingEnvironmentVariables.length) {
     throw new Error(
-      `The following environment variables are missing. Your site will not work without them.\n\n${missingEnvironmentVariables.join(
+      `The following environment variables are missing. Your site will not work without them. Read more: https://vercel.com/docs/integrations/shopify#configure-environment-variables\n\n${missingEnvironmentVariables.join(
         '\n'
       )}\n`
     );

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -9,3 +9,18 @@ export const createUrl = (pathname: string, params: URLSearchParams | ReadonlyUR
 
 export const ensureStartsWith = (stringToCheck: string, startsWith: string) =>
   stringToCheck.startsWith(startsWith) ? stringToCheck : `${startsWith}${stringToCheck}`;
+
+export const validateEnvironmentVariables = () => {
+  const requiredEnvironmentVariables = ['SHOPIFY_STORE_DOMAIN', 'SHOPIFY_STOREFRONT_ACCESS_TOKEN'];
+  const missingEnvironmentVariables = [] as string[];
+
+  requiredEnvironmentVariables.forEach((envVar) => {
+    if (!process.env[envVar]) {
+      missingEnvironmentVariables.push(envVar);
+    }
+  });
+
+  if (missingEnvironmentVariables.length) {
+    throw new Error(`The following environment variables are missing. Your site will not work without them.\n\n${missingEnvironmentVariables.join('\n')}\n`);
+  }
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -23,4 +23,8 @@ export const validateEnvironmentVariables = () => {
   if (missingEnvironmentVariables.length) {
     throw new Error(`The following environment variables are missing. Your site will not work without them.\n\n${missingEnvironmentVariables.join('\n')}\n`);
   }
+
+  if (process.env.SHOPIFY_STORE_DOMAIN?.includes('[') || process.env.SHOPIFY_STORE_DOMAIN?.includes(']')) {
+    throw new Error('Your `SHOPIFY_STORE_DOMAIN` environment variable includes brackets (ie. `[` and / or `]`). Your site will not work with them there. Please remove them.');
+  }
 }


### PR DESCRIPTION
We get 1 -3 issues or comments a week about build errors (see #1189 and #1197, for example), which are due to missing environment variables.

This PR add some validation during the build process to ensure absolutely required env vars are present and throws a clearer error message.

![CleanShot 2023-09-16 at 19 59 28@2x](https://github.com/vercel/commerce/assets/446260/d2167133-801a-4177-a3f0-0043247b05cf)