### PR TITLE
Fix: Type error

### DIFF
--- a/app/[page]/layout.tsx
+++ b/app/[page]/layout.tsx
@@ -6,7 +6,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     <Suspense>
       <div className="w-full">
         <div className="mx-8 max-w-2xl py-20 sm:mx-auto">
-          <Suspense>{children}</Suspense>
+          <Suspense>
+            <>{children}</>
+          </Suspense>
         </div>
       </div>
       <Footer />


### PR DESCRIPTION
It shows an Type error:
Type 'ReactElement<any, string | JSXElementConstructor<any>>' is not assignable to type 'ReactNode'.
Property 'children' is missing in type 'ReactElement<any, string | JSXElementConstructor<any>>' but required in type 'ReactPortal'.

Enclosing it with any valid html tag will solve the error.