### PR TITLE
replace cancel-workflow-action with Github's concurrency property to cancel in progress workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,16 @@
 name: test
 on: pull_request
+
+# Cancel in progress workflows on pull_requests.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel running workflows
-        uses: styfle/cancel-workflow-action@0.12.0
-        with:
-          access_token: ${{ github.token }}
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Set node version


### PR DESCRIPTION
Just wanted to start by saying that the reason for this PR is that I had some issues with the cancel-workflow-action when working on a project that was kickstarted by using this amazing project as a starter. Happy to get into details on that if needed but regardless I do feel there is a strong case for removing the action:

Using the [cancel-workflow-action](https://github.com/styfle/cancel-workflow-action) to cancel in progress workflows can be replaced with Github's native concurrency property.

The cancel-workflow-action even has a warning in its [readme](https://github.com/styfle/cancel-workflow-action#readme) that the action is probably no longer needed.

This PR changes it so that test.yml workflow uses the concurrency property instead of the cancel-workflow-action. The concurrency group is the same as [Sentry is using](https://github.com/getsentry/sentry/blob/d5bde7eccf4af765011a24037b0acbc428df6911/.github/workflows/frontend.yml#L9-L13) in their Github workflows.