### PR TITLE
Remove revalidate

### DIFF
--- a/app/[page]/page.tsx
+++ b/app/[page]/page.tsx
@@ -6,8 +6,6 @@ import { notFound } from 'next/navigation';
 
 export const runtime = 'edge';
 
-export const revalidate = 43200; // 12 hours in seconds
-
 export async function generateMetadata({
   params
 }: {


### PR DESCRIPTION
Remove revalidate as there is currently no cache support for the Edge runtime.