### PR TITLE
Removing useEffects that have no side effect and alter the state.

### DIFF
--- a/components/layout/footer-menu.tsx
+++ b/components/layout/footer-menu.tsx
@@ -4,15 +4,10 @@ import clsx from 'clsx';
 import { Menu } from 'lib/shopify/types';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useEffect, useState } from 'react';
 
 const FooterMenuItem = ({ item }: { item: Menu }) => {
   const pathname = usePathname();
-  const [active, setActive] = useState(pathname === item.path);
-
-  useEffect(() => {
-    setActive(pathname === item.path);
-  }, [pathname, item.path]);
+  const active = pathname === item.path;
 
   return (
     <li>

--- a/components/layout/navbar/mobile-menu.tsx
+++ b/components/layout/navbar/mobile-menu.tsx
@@ -16,6 +16,17 @@ export default function MobileMenu({ menu }: { menu: Menu[] }) {
   const openMobileMenu = () => setIsOpen(true);
   const closeMobileMenu = () => setIsOpen(false);
 
+  const [prevPathname, setPrevPathname] = useState(pathname);
+  const [prevSearchParams, setPrevSearchParams] = useState(searchParams);
+  if (prevPathname !== pathname) {
+    setPrevPathname(pathname);
+    setIsOpen(false);
+  }
+  if (!Object.is(prevSearchParams, searchParams)) {
+    setIsOpen(false);
+    setPrevSearchParams(searchParams);
+  }
+
   useEffect(() => {
     const handleResize = () => {
       if (window.innerWidth > 768) {
@@ -25,10 +36,6 @@ export default function MobileMenu({ menu }: { menu: Menu[] }) {
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, [isOpen]);
-
-  useEffect(() => {
-    setIsOpen(false);
-  }, [pathname, searchParams]);
 
   return (
     <>

--- a/components/layout/search/filter/dropdown.tsx
+++ b/components/layout/search/filter/dropdown.tsx
@@ -10,10 +10,16 @@ import { FilterItem } from './item';
 export default function FilterItemDropdown({ list }: { list: ListItem[] }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const [active, setActive] = useState('');
   const [openSelect, setOpenSelect] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
+  const active =
+    list.findLast(
+      (listItem: ListItem) => (
+        ('path' in listItem && pathname === listItem.path) ||
+        ('slug' in listItem && searchParams.get('sort') === listItem.slug)
+    ))?.title ?? '';
+  
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (ref.current && !ref.current.contains(event.target as Node)) {
@@ -24,17 +30,6 @@ export default function FilterItemDropdown({ list }: { list: ListItem[] }) {
     window.addEventListener('click', handleClickOutside);
     return () => window.removeEventListener('click', handleClickOutside);
   }, []);
-
-  useEffect(() => {
-    list.forEach((listItem: ListItem) => {
-      if (
-        ('path' in listItem && pathname === listItem.path) ||
-        ('slug' in listItem && searchParams.get('sort') === listItem.slug)
-      ) {
-        setActive(listItem.title);
-      }
-    });
-  }, [pathname, list, searchParams]);
 
   return (
     <div className="relative" ref={ref}>


### PR DESCRIPTION
It is recommended by the React Docs to avoid unnecessarily changing the state within a useEffect.
As React Docs says: "Storing information from previous renders like this can be hard to understand, but it’s better than updating the same state in an Effect."