### PR TITLE
disable the image optimization

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ module.exports = {
   },
   images: {
     formats: ['image/avif', 'image/webp'],
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
next commerce receives it's images from the headless cms, where the images are optimized,
so you can disable the image optimization.

the reason i disabled it, is that i got images with src as follows:
src="/_next/image?url=http%3A%2F%2F127.0.0.1%3A3001%2Fmedia-main%2Fzte_nubia_red_magic_8_pro-100x124.webp&amp;w=3840&amp;q=75"

which is "http://127.0.0.1:3001/media-main/zte_nubia_red_magic_8_pro-100x124.webp&w=3840&q=75"

so you can note that after ".webp" you expect to have "?" 
and without that the image not found.



so my solution was to disable the image optimization which anyway not being used y commerce (since its receives optimized images from api)
