### PR TITLE
disable the image optimization

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ module.exports = {
   },
   images: {
     formats: ['image/avif', 'image/webp'],
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
disabling the next/image optimization because:
1. the headless CMS do the image optimizations instead of next/image.
2. image/next optimization makes links such as `http://127.0.0.1:3001/media-main/image1-100x124.webp&w=3840&q=75`.
this link is illegible and throws 404 since after the .webp you expect to have "?".

