### PR TITLE
Implement 'Compare at Price' Feature

### DIFF
--- a/components/product/product-description.tsx
+++ b/components/product/product-description.tsx
@@ -5,15 +5,23 @@ import { Product } from 'lib/shopify/types';
 import { VariantSelector } from './variant-selector';
 
 export function ProductDescription({ product }: { product: Product }) {
+  const compareAtPrice = product.compareAtPriceRange.maxVariantPrice.amount;
+  const price = product.priceRange.maxVariantPrice.amount;
+
   return (
     <>
       <div className="mb-6 flex flex-col border-b pb-6 dark:border-neutral-700">
         <h1 className="mb-2 text-5xl font-medium">{product.title}</h1>
+        {parseFloat(compareAtPrice) > parseFloat(price) && (
+          <div className="mr-auto w-auto p-2 text-sm text-white line-through decoration-red-500">
+            <Price
+              amount={compareAtPrice}
+              currencyCode={product.priceRange.maxVariantPrice.currencyCode}
+            />
+          </div>
+        )}
         <div className="mr-auto w-auto rounded-full bg-blue-600 p-2 text-sm text-white">
-          <Price
-            amount={product.priceRange.maxVariantPrice.amount}
-            currencyCode={product.priceRange.maxVariantPrice.currencyCode}
-          />
+          <Price amount={price} currencyCode={product.priceRange.maxVariantPrice.currencyCode} />
         </div>
       </div>
       <VariantSelector options={product.options} variants={product.variants} />

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -28,4 +28,4 @@ export const TAGS = {
 
 export const HIDDEN_PRODUCT_TAG = 'nextjs-frontend-hidden';
 export const DEFAULT_OPTION = 'Default Title';
-export const SHOPIFY_GRAPHQL_API_ENDPOINT = '/api/2023-01/graphql.json';
+export const SHOPIFY_GRAPHQL_API_ENDPOINT = '/api/2023-10/graphql.json';

--- a/lib/shopify/fragments/product.ts
+++ b/lib/shopify/fragments/product.ts
@@ -24,6 +24,16 @@ const productFragment = /* GraphQL */ `
         currencyCode
       }
     }
+    compareAtPriceRange {
+      maxVariantPrice {
+        amount
+        currencyCode
+      }
+      minVariantPrice {
+        amount
+        currencyCode
+      }
+    }
     variants(first: 250) {
       edges {
         node {

--- a/lib/shopify/types.ts
+++ b/lib/shopify/types.ts
@@ -120,6 +120,10 @@ export type ShopifyProduct = {
     maxVariantPrice: Money;
     minVariantPrice: Money;
   };
+  compareAtPriceRange: {
+    maxVariantPrice: Money;
+    minVariantPrice: Money;
+  };
   variants: Connection<ProductVariant>;
   featuredImage: Image;
   images: Connection<Image>;


### PR DESCRIPTION
Description

This Pull Request introduces the 'Compare at Price' feature to our e-commerce platform. The primary goal of this feature is to enhance the user shopping experience by displaying a comparison between the original price and the current sale price of products. This feature is especially beneficial for promotional events, allowing customers to see the value they are getting from discounted prices.

How It Works

The feature retrieves the compare-at price and the normal price from the product fetch. These prices are then displayed side by side on the product page. A strikethrough style is applied to the original price to denote the discount.