### PR TITLE
Correct default cart tax currency

### DIFF
--- a/lib/shopify/index.ts
+++ b/lib/shopify/index.ts
@@ -122,7 +122,7 @@ const reshapeCart = (cart: ShopifyCart): Cart => {
   if (!cart.cost?.totalTaxAmount) {
     cart.cost.totalTaxAmount = {
       amount: '0.0',
-      currencyCode: 'USD'
+      currencyCode: cart.cost.totalAmount.currencyCode
     };
   }
 


### PR DESCRIPTION
The cart defaults the tax to be `USD` if there is no tax amount set for the cart. This is an unhelpful default due to international and multi currency stores where the currency changes with the cart (most of the this repo handles this correctly).

This changes defaults the currency to the same currency as the cart total currency if there are no taxes set for the current cart.

Before:
![Screenshot 2023-12-15 at 14 55 28](https://github.com/vercel/commerce/assets/30322136/a466aad5-d230-44cd-b178-e1be2b82fece)

After:
![Screenshot 2023-12-15 at 14 55 38](https://github.com/vercel/commerce/assets/30322136/aa9f61d8-a8d0-4011-b97d-d41ef1d2c597)
