### PR TITLE
Fix #1283: Added hover effect to search icon.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,8 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll": true,
-    "source.organizeImports": true,
-    "source.sortMembers": true
+    "source.fixAll": "explicit",
+    "source.organizeImports": "explicit",
+    "source.sortMembers": "explicit"
   }
 }

--- a/components/layout/navbar/search.tsx
+++ b/components/layout/navbar/search.tsx
@@ -35,7 +35,7 @@ export default function Search() {
         defaultValue={searchParams?.get('q') || ''}
         className="w-full rounded-lg border bg-white px-4 py-2 text-sm text-black placeholder:text-neutral-500 dark:border-neutral-800 dark:bg-transparent dark:text-white dark:placeholder:text-neutral-400"
       />
-      <div className="absolute right-0 top-0 mr-3 flex h-full items-center">
+      <div className="absolute right-0 top-0 mr-3 flex h-full items-center hover:text-black dark:hover:text-neutral-300">
         <MagnifyingGlassIcon className="h-4" />
       </div>
     </form>


### PR DESCRIPTION
Add hover effect to search icon

Fixes #1283

In this commit, I've added a hover effect to the search icon as requested in issue #1283. Now, users will experience a visual cue when hovering over the search icon, enhancing the overall user experience. 

Contributed by: the-kaif
