### PR TITLE
fix: disabled button classes when selectedVariantId is defined are not being set

### DIFF
--- a/components/cart/add-to-cart.tsx
+++ b/components/cart/add-to-cart.tsx
@@ -52,7 +52,7 @@ function SubmitButton({
       aria-disabled={pending}
       className={clsx(buttonClasses, {
         'hover:opacity-90': true,
-        disabledClasses: pending
+        [disabledClasses]: pending
       })}
     >
       <div className="absolute left-0 ml-4">


### PR DESCRIPTION
Just a small fix:

The used class was `"disabledClasses"` instead of what is contained in the `disabledClasses` const