### PR TITLE
Update URL for the Shopify Integration Guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ Your app should now be running on [localhost:3000](http://localhost:3000/).
 
 ## Vercel, Next.js Commerce, and Shopify Integration Guide
 
-You can use this comprehensive [integration guide](http://vercel.com/docs/integrations/shopify) with step-by-step instructions on how to configure Shopify as a headless CMS using Next.js Commerce as your headless Shopify storefront on Vercel.
+You can use this comprehensive [integration guide](https://vercel.com/docs/integrations/ecommerce/shopify) with step-by-step instructions on how to configure Shopify as a headless CMS using Next.js Commerce as your headless Shopify storefront on Vercel.


### PR DESCRIPTION
The current URL linking to the Shopify Integration Guide is http://vercel.com/docs/integrations/shopify, which redirects to https://vercel.com/docs/integrations/cms/shopify and shows a 404. 

<img width="1440" alt="Screen Shot" src="https://github.com/vercel/commerce/assets/152337579/12ee215c-924e-495f-a48c-dab6d76f60e1">

The correct URL that holds the content now seems to live on https://vercel.com/docs/integrations/ecommerce/shopify, which is updated in this PR.

<img width="1440" alt="Screen Shot 2" src="https://github.com/vercel/commerce/assets/152337579/1de011db-5bd4-4058-89bc-8b9ae34e86fc">
