### PR TITLE
Remove `any` type and make `removeEdgesAndNodes` generic

### DIFF
--- a/lib/shopify/index.ts
+++ b/lib/shopify/index.ts
@@ -114,7 +114,7 @@ export async function shopifyFetch<T>({
   }
 }
 
-const removeEdgesAndNodes = (array: Connection<any>) => {
+const removeEdgesAndNodes = <T>(array: Connection<T>): T[] => {
   return array.edges.map((edge) => edge?.node);
 };
 
@@ -163,7 +163,7 @@ const reshapeImages = (images: Connection<Image>, productTitle: string) => {
   const flattened = removeEdgesAndNodes(images);
 
   return flattened.map((image) => {
-    const filename = image.url.match(/.*\/(.*)\..*/)[1];
+    const filename = image.url.match(/.*\/(.*)\..*/)?.[1];
     return {
       ...image,
       altText: image.altText || `${productTitle} - ${filename}`


### PR DESCRIPTION
Improves type inference of the `removeEdgesAndNodes` method

| Before  |  After |
|---|---|
| <img width="903" alt="Screenshot 2024-07-14 at 9 19 10 PM" src="https://github.com/user-attachments/assets/9c7f03ca-9ff3-4078-b1c4-ac7bb2a86355">  |  <img width="900" alt="Screenshot 2024-07-14 at 9 19 43 PM" src="https://github.com/user-attachments/assets/47e78412-533b-463c-8c6e-d3390cefa797"> |

