### PR TITLE
feat(design): Show carousel above the fold on desktop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env*.local

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,3 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-.env*.local

--- a/components/grid/three-items.tsx
+++ b/components/grid/three-items.tsx
@@ -52,7 +52,7 @@ export async function ThreeItemGrid() {
   const [firstProduct, secondProduct, thirdProduct] = homepageItems;
 
   return (
-    <section className="mx-auto grid max-w-screen-2xl gap-4 px-4 pb-4 md:grid-cols-6 md:grid-rows-2">
+    <section className="mx-auto grid max-w-screen-2xl gap-4 px-4 pb-4 md:grid-cols-6 md:grid-rows-2 lg:max-h-[calc(100vh-200px)]">
       <ThreeItemGridItem size="full" item={firstProduct} priority={true} />
       <ThreeItemGridItem size="half" item={secondProduct} priority={true} />
       <ThreeItemGridItem size="half" item={thirdProduct} />


### PR DESCRIPTION
Before this commit, we would not see the carousel without scrolling. The top images are so big that they take up most of the space. This made the website look buggy (opinion). Thus, I am proposing this change.

**Before**
![CleanShot 2024-07-25 at 11 38 17@2x](https://github.com/user-attachments/assets/9c1432d5-6665-481d-a64f-7731ccea5dc8)

**After**
![CleanShot 2024-07-25 at 11 39 03@2x](https://github.com/user-attachments/assets/7ab0463b-7f75-4db5-a830-f8c6f771a6b5)
