### PR TITLE
no-store cache for shopify menu fetch

### DIFF
--- a/lib/shopify/index.ts
+++ b/lib/shopify/index.ts
@@ -343,7 +343,7 @@ export async function getCollections(): Promise<Collection[]> {
 export async function getMenu(handle: string): Promise<Menu[]> {
   const res = await shopifyFetch<ShopifyMenuOperation>({
     query: getMenuQuery,
-    tags: [TAGS.collections],
+    cache: 'no-store',
     variables: {
       handle
     }


### PR DESCRIPTION
Shopify currently does not seem to provide a webhook for updating the Navigation Menus under the Online Store. Also this function was using the tag for collections, which is not related. Removing the tag and adding a `no-store` cache.