### PR TITLE
Add Shopify Storefront API compareAtPriceRange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /node_modules
 /.pnp
 .pnp.js
+yarn.lock
+package-lock.json
 
 # testing
 /coverage

--- a/lib/shopify/fragments/product.ts
+++ b/lib/shopify/fragments/product.ts
@@ -14,6 +14,16 @@ const productFragment = /* GraphQL */ `
       name
       values
     }
+    compareAtPriceRange {
+      maxVariantPrice {
+        amount
+        currencyCode
+      }
+      minVariantPrice {
+        amount
+        currencyCode
+      }
+    }
     priceRange {
       maxVariantPrice {
         amount

--- a/lib/shopify/types.ts
+++ b/lib/shopify/types.ts
@@ -123,6 +123,10 @@ export type ShopifyProduct = {
   description: string;
   descriptionHtml: string;
   options: ProductOption[];
+  compareAtPriceRange: {
+    maxVariantPrice: Money;
+    minVariantPrice: Money;
+  };
   priceRange: {
     maxVariantPrice: Money;
     minVariantPrice: Money;


### PR DESCRIPTION
This gets [`compareAtPriceRange`](https://shopify.dev/docs/api/storefront/2024-10/objects/Product#field-compareatpricerange) from the Storefront API so you have the option to render `comparePriceRange` with `priceRange` if you want to render price percentage discounts.

