### PR TITLE
docs: add comments to .env.example explaining how to get Shopify env …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,28 @@
 COMPANY_NAME="Vercel Inc."
 SITE_NAME="Next.js Commerce"
-SHOPIFY_REVALIDATION_SECRET=""
+
+# Required for Shopify Storefront API access.
+# To get this token:
+# 1. Go to your Shopify Admin > Apps > Develop apps
+# 2. Create a new app (or open an existing one)
+# 3. Go to the "Configuration" tab and enable the Storefront API scopes you need
+# 4. Click "Save", then go to the "API credentials" tab
+# 5. Under "Storefront API access token", click "Install app" if prompted, then copy the token
+# See: https://shopify.dev/docs/storefronts/headless/building-with-the-storefront-api/getting-started
 SHOPIFY_STOREFRONT_ACCESS_TOKEN=""
+
+# A secret string you choose yourself (e.g. a random UUID or password).
+# This is used to authenticate webhook requests from Shopify for on-demand revalidation.
+# To set it up:
+# 1. Generate a random secret string (e.g. run: openssl rand -hex 32)
+# 2. Set this env var to that secret string
+# 3. In Shopify Admin > Settings > Notifications > Webhooks, create a webhook pointing to
+#    https://your-domain.com/api/revalidate?secret=<your-secret> for events like
+#    product updates, collection updates, etc.
+# See: https://shopify.dev/docs/apps/build/webhooks
+SHOPIFY_REVALIDATION_SECRET=""
+
+# Your Shopify store's myshopify.com domain.
+# Example: if your store URL is https://my-store.myshopify.com, use: my-store.myshopify.com
+# Find this in Shopify Admin > Settings > Domains
 SHOPIFY_STORE_DOMAIN="[your-shopify-store-subdomain].myshopify.com"


### PR DESCRIPTION
## Summary

Fixes #1517

Users were confused about where to obtain the required Shopify environment variables (`SHOPIFY_STOREFRONT_ACCESS_TOKEN`, `SHOPIFY_REVALIDATION_SECRET`, `SHOPIFY_STORE_DOMAIN`) when setting up Next.js Commerce.

## Changes

Added inline comments to `.env.example` with step-by-step instructions explaining:

- **`SHOPIFY_STOREFRONT_ACCESS_TOKEN`**: How to navigate to Shopify Admin → Apps → Develop apps, create/configure an app with Storefront API scopes, and copy the access token from API credentials.
- - **`SHOPIFY_REVALIDATION_SECRET`**: That this is a self-chosen secret string (not from Shopify's app credentials), and how to generate one and configure Shopify webhooks to use it.
- - **`SHOPIFY_STORE_DOMAIN`**: How to find the store's `.myshopify.com` subdomain.
## Motivation

The original `.env.example` had empty values with no guidance, causing confusion for new contributors (ref: issue #1517). The `SHOPIFY_REVALIDATION_SECRET` in particular is easy to confuse with Shopify's app "client secret" — this PR clarifies that it is a user-generated value used to authenticate webhook requests.