### PR TITLE
Fix stored XSS in product JSON-LD via unescaped JSON.stringify (CWE-79)

### DIFF
--- a/app/product/[handle]/page.tsx
+++ b/app/product/[handle]/page.tsx
@@ -77,7 +77,9 @@ export default async function ProductPage(props: {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify(productJsonLd),
+          __html: JSON.stringify(productJsonLd)
+            .replace(/</g, "\\u003c")
+            .replace(/>/g, "\\u003e"),
         }}
       />
       <div className="mx-auto max-w-(--breakpoint-2xl) px-4">


### PR DESCRIPTION
## Security Fix — Stored XSS in Product JSON-LD (CWE-79)

### Summary

Product pages render a JSON-LD `<script>` block using `dangerouslySetInnerHTML` with raw `JSON.stringify` output. Because `JSON.stringify` does not escape `<` or `>`, a product title or description containing `</script>` terminates the JSON-LD block prematurely, allowing an attacker-controlled `<script>` tag to execute in the customer's browser.

This is a **stored XSS** affecting any customer who visits a product page with a malicious title, description, or image URL — injected via the Shopify admin (compromised credentials, rogue admin, API abuse).

### Affected file

**`app/product/[handle]/page.tsx` line 79–82**

### Root cause

```tsx
// Vulnerable — JSON.stringify does NOT escape < or >
<script
  type="application/ld+json"
  dangerouslySetInnerHTML={{
    __html: JSON.stringify(productJsonLd),
  }}
/>
```

A product title of `</script><script>alert(1)</script>` produces:

```html
<script type="application/ld+json">{"name":"</script><script>alert(1)</script>"...}</script>
```

The browser terminates the JSON-LD block at the first `</script>`, then executes the injected script.

### Fix

```tsx
<script
  type="application/ld+json"
  dangerouslySetInnerHTML={{
    __html: JSON.stringify(productJsonLd)
      .replace(/</g, "\\u003c")
      .replace(/>/g, "\\u003e"),
  }}
/>
```

`<` / `>` are valid JSON Unicode escapes that browsers and JSON parsers decode as `<`/`>`, so structured-data consumers see the correct values — but no `</script>` sequence can appear in the raw HTML.

### Impact

- **Type**: Stored XSS — CWE-79
- **Trigger**: Shopify admin sets malicious product title/description (compromised account, rogue employee, API token with `write_products` scope)
- **Consequence**: Arbitrary JavaScript executes in every customer's browser on the product page — session cookie theft, payment skimming, phishing redirects

### Verification

Confirmed via Node.js runtime — `JSON.stringify` does not escape angle brackets:

```
node -e "const o={name:'</script><script>alert(1)</script>'}; console.log(JSON.stringify(o))"
# Output: {"name":"</script><script>alert(1)</script>"}   ← unescaped
```